### PR TITLE
(PR 2 of 3) Add resources implementation to the updated ccv3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,3 +253,6 @@ vet: ## Run go vet
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-34s\033[0m %s\n", $$1, $$2}'
+
+vet-api:
+	go vet -all  ./api/...

--- a/api/cloudcontroller/ccerror/application_not_found_error.go
+++ b/api/cloudcontroller/ccerror/application_not_found_error.go
@@ -1,10 +1,17 @@
 package ccerror
 
+import "fmt"
+
 // ApplicationNotFoundError is returned when an endpoint cannot find the
 // specified application
 type ApplicationNotFoundError struct {
+	Name string
 }
 
 func (e ApplicationNotFoundError) Error() string {
+	if e.Name != "" {
+		return fmt.Sprintf("App '%s' not found.", e.Name)
+	}
+
 	return "Application not found"
 }

--- a/api/cloudcontroller/ccerror/buildpack_invalid_error.go
+++ b/api/cloudcontroller/ccerror/buildpack_invalid_error.go
@@ -1,0 +1,9 @@
+package ccerror
+
+type BuildpackInvalidError struct {
+	Message string
+}
+
+func (e BuildpackInvalidError) Error() string {
+	return e.Message
+}

--- a/api/cloudcontroller/ccerror/job_failed_no_error.go
+++ b/api/cloudcontroller/ccerror/job_failed_no_error.go
@@ -1,0 +1,15 @@
+package ccerror
+
+import (
+	"fmt"
+)
+
+// V3JobFailedError represents a failed Cloud Controller Job. It wraps the error
+// returned back from the Cloud Controller.
+type JobFailedNoErrorError struct {
+	JobGUID string
+}
+
+func (e JobFailedNoErrorError) Error() string {
+	return fmt.Sprintf("Job (%s) failed with no error. This is unexpected, contact your operator for details.", e.JobGUID)
+}

--- a/api/cloudcontroller/ccerror/service_instance_not_found_error.go
+++ b/api/cloudcontroller/ccerror/service_instance_not_found_error.go
@@ -1,0 +1,13 @@
+package ccerror
+
+import "fmt"
+
+// ServiceInstanceNotFoundError is returned when an endpoint cannot find the
+// specified service instance
+type ServiceInstanceNotFoundError struct {
+	Name, SpaceGUID string
+}
+
+func (e ServiceInstanceNotFoundError) Error() string {
+	return fmt.Sprintf("Service instance '%s' not found in space '%s'.", e.Name, e.SpaceGUID)
+}

--- a/api/cloudcontroller/ccerror/service_offering_name_ambiguity_error.go
+++ b/api/cloudcontroller/ccerror/service_offering_name_ambiguity_error.go
@@ -1,0 +1,21 @@
+package ccerror
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ServiceOfferingNameAmbiguityError struct {
+	ServiceOfferingName string
+	ServiceBrokerNames  []string
+}
+
+func (e ServiceOfferingNameAmbiguityError) Error() string {
+	const msg = "Service '%s' is provided by multiple service brokers%s"
+	switch len(e.ServiceBrokerNames) {
+	case 0:
+		return fmt.Sprintf(msg, e.ServiceOfferingName, ".")
+	default:
+		return fmt.Sprintf(msg, e.ServiceOfferingName, ": "+strings.Join(e.ServiceBrokerNames, ", "))
+	}
+}

--- a/api/cloudcontroller/ccerror/service_offering_not_found_error.go
+++ b/api/cloudcontroller/ccerror/service_offering_not_found_error.go
@@ -1,0 +1,23 @@
+package ccerror
+
+import "fmt"
+
+type ServiceOfferingNotFoundError struct {
+	ServiceOfferingName, ServiceBrokerName string
+}
+
+func (e ServiceOfferingNotFoundError) Error() string {
+	if e.ServiceOfferingName != "" && e.ServiceBrokerName != "" {
+		return fmt.Sprintf("Service offering '%s' for service broker '%s' not found.", e.ServiceOfferingName, e.ServiceBrokerName)
+	}
+
+	if e.ServiceOfferingName != "" {
+		return fmt.Sprintf("Service offering '%s' not found.", e.ServiceOfferingName)
+	}
+
+	if e.ServiceBrokerName != "" {
+		return fmt.Sprintf("No service offerings found for service broker '%s'.", e.ServiceBrokerName)
+	}
+
+	return "No service offerings found."
+}

--- a/api/cloudcontroller/ccv3/application.go
+++ b/api/cloudcontroller/ccv3/application.go
@@ -1,261 +1,106 @@
 package ccv3
 
 import (
-	"bytes"
-	"encoding/json"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
 )
 
-// Application represents a Cloud Controller V3 Application.
-type Application struct {
-	// GUID is the unique application identifier.
-	GUID string
-	// StackName is the name of the stack on which the application runs.
-	StackName string
-	// LifecycleBuildpacks is a list of the names of buildpacks.
-	LifecycleBuildpacks []string
-	// LifecycleType is the type of the lifecycle.
-	LifecycleType constant.AppLifecycleType
-	// Metadata is used for custom tagging of API resources
-	Metadata *Metadata
-	// Name is the name given to the application.
-	Name string
-	// Relationships list the relationships to the application.
-	Relationships Relationships
-	// State is the desired state of the application.
-	State constant.ApplicationState
-}
-
-// MarshalJSON converts an Application into a Cloud Controller Application.
-func (a Application) MarshalJSON() ([]byte, error) {
-	ccApp := ccApplication{
-		Name:          a.Name,
-		Relationships: a.Relationships,
-		Metadata:      a.Metadata,
-	}
-
-	if a.LifecycleType == constant.AppLifecycleTypeDocker {
-		ccApp.setDockerLifecycle()
-	} else if a.LifecycleType == constant.AppLifecycleTypeBuildpack {
-		if len(a.LifecycleBuildpacks) > 0 || a.StackName != "" {
-			if a.hasAutodetectedBuildpack() {
-				ccApp.setAutodetectedBuildpackLifecycle(a)
-			} else {
-				ccApp.setBuildpackLifecycle(a)
-			}
-		}
-	}
-
-	return json.Marshal(ccApp)
-}
-
-// UnmarshalJSON helps unmarshal a Cloud Controller Application response.
-func (a *Application) UnmarshalJSON(data []byte) error {
-	lifecycle := ccLifecycle{}
-	ccApp := ccApplication{
-		Lifecycle: &lifecycle,
-	}
-
-	err := cloudcontroller.DecodeJSON(data, &ccApp)
-	if err != nil {
-		return err
-	}
-
-	a.GUID = ccApp.GUID
-	a.StackName = lifecycle.Data.Stack
-	a.LifecycleBuildpacks = lifecycle.Data.Buildpacks
-	a.LifecycleType = lifecycle.Type
-	a.Name = ccApp.Name
-	a.Relationships = ccApp.Relationships
-	a.State = ccApp.State
-	a.Metadata = ccApp.Metadata
-
-	return nil
-}
-
-func (a Application) hasAutodetectedBuildpack() bool {
-	if len(a.LifecycleBuildpacks) == 0 {
-		return false
-	}
-	return a.LifecycleBuildpacks[0] == constant.AutodetectBuildpackValueDefault || a.LifecycleBuildpacks[0] == constant.AutodetectBuildpackValueNull
-}
-
-type ccLifecycle struct {
-	Type constant.AppLifecycleType `json:"type,omitempty"`
-	Data struct {
-		Buildpacks []string `json:"buildpacks,omitempty"`
-		Stack      string   `json:"stack,omitempty"`
-	} `json:"data"`
-}
-
-type ccApplication struct {
-	Name          string                    `json:"name,omitempty"`
-	Relationships Relationships             `json:"relationships,omitempty"`
-	Lifecycle     interface{}               `json:"lifecycle,omitempty"`
-	GUID          string                    `json:"guid,omitempty"`
-	State         constant.ApplicationState `json:"state,omitempty"`
-	Metadata      *Metadata                 `json:"metadata,omitempty"`
-}
-
-func (ccApp *ccApplication) setAutodetectedBuildpackLifecycle(a Application) {
-	var nullBuildpackLifecycle struct {
-		Type constant.AppLifecycleType `json:"type,omitempty"`
-		Data struct {
-			Buildpacks []string `json:"buildpacks"`
-			Stack      string   `json:"stack,omitempty"`
-		} `json:"data"`
-	}
-	nullBuildpackLifecycle.Type = constant.AppLifecycleTypeBuildpack
-	nullBuildpackLifecycle.Data.Stack = a.StackName
-	ccApp.Lifecycle = nullBuildpackLifecycle
-}
-
-func (ccApp *ccApplication) setBuildpackLifecycle(a Application) {
-	var lifecycle ccLifecycle
-	lifecycle.Type = a.LifecycleType
-	lifecycle.Data.Buildpacks = a.LifecycleBuildpacks
-	lifecycle.Data.Stack = a.StackName
-	ccApp.Lifecycle = lifecycle
-}
-
-func (ccApp *ccApplication) setDockerLifecycle() {
-	ccApp.Lifecycle = ccLifecycle{
-		Type: constant.AppLifecycleTypeDocker,
-	}
-}
-
 // CreateApplication creates an application with the given settings.
-func (client *Client) CreateApplication(app Application) (Application, Warnings, error) {
-	bodyBytes, err := json.Marshal(app)
-	if err != nil {
-		return Application{}, nil, err
-	}
+func (client *Client) CreateApplication(app resources.Application) (resources.Application, Warnings, error) {
+	var responseBody resources.Application
 
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostApplicationRequest,
-		Body:        bytes.NewReader(bodyBytes),
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostApplicationRequest,
+		RequestBody:  app,
+		ResponseBody: &responseBody,
 	})
+
+	return responseBody, warnings, err
+}
+
+func (client *Client) GetApplicationByNameAndSpace(appName string, spaceGUID string) (resources.Application, Warnings, error) {
+	apps, warnings, err := client.GetApplications(
+		Query{Key: NameFilter, Values: []string{appName}},
+		Query{Key: SpaceGUIDFilter, Values: []string{spaceGUID}},
+	)
 	if err != nil {
-		return Application{}, nil, err
+		return resources.Application{}, warnings, err
 	}
 
-	var responseApp Application
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseApp,
+	if len(apps) == 0 {
+		return resources.Application{}, warnings, ccerror.ApplicationNotFoundError{Name: appName}
 	}
-	err = client.connection.Make(request, &response)
 
-	return responseApp, response.Warnings, err
+	return apps[0], warnings, nil
 }
 
 // GetApplications lists applications with optional queries.
-func (client *Client) GetApplications(query ...Query) ([]Application, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetApplicationsRequest,
-		Query:       query,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
+func (client *Client) GetApplications(query ...Query) ([]resources.Application, Warnings, error) {
+	var apps []resources.Application
 
-	var fullAppsList []Application
-	warnings, err := client.paginate(request, Application{}, func(item interface{}) error {
-		if app, ok := item.(Application); ok {
-			fullAppsList = append(fullAppsList, app)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   Application{},
-				Unexpected: item,
-			}
-		}
-		return nil
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetApplicationsRequest,
+		Query:        query,
+		ResponseBody: resources.Application{},
+		AppendToList: func(item interface{}) error {
+			apps = append(apps, item.(resources.Application))
+			return nil
+		},
 	})
 
-	return fullAppsList, warnings, err
+	return apps, warnings, err
 }
 
 // UpdateApplication updates an application with the given settings.
-func (client *Client) UpdateApplication(app Application) (Application, Warnings, error) {
-	bodyBytes, err := json.Marshal(app)
-	if err != nil {
-		return Application{}, nil, err
-	}
+func (client *Client) UpdateApplication(app resources.Application) (resources.Application, Warnings, error) {
+	var responseBody resources.Application
 
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PatchApplicationRequest,
-		Body:        bytes.NewReader(bodyBytes),
-		URIParams:   map[string]string{"app_guid": app.GUID},
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PatchApplicationRequest,
+		URIParams:    internal.Params{"app_guid": app.GUID},
+		RequestBody:  app,
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Application{}, nil, err
-	}
 
-	var responseApp Application
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseApp,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responseApp, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // UpdateApplicationRestart restarts the given application.
-func (client *Client) UpdateApplicationRestart(appGUID string) (Application, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostApplicationActionRestartRequest,
-		URIParams:   map[string]string{"app_guid": appGUID},
+func (client *Client) UpdateApplicationRestart(appGUID string) (resources.Application, Warnings, error) {
+	var responseBody resources.Application
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostApplicationActionRestartRequest,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Application{}, nil, err
-	}
 
-	var responseApp Application
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseApp,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responseApp, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // UpdateApplicationStart starts the given application.
-func (client *Client) UpdateApplicationStart(appGUID string) (Application, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostApplicationActionStartRequest,
-		URIParams:   map[string]string{"app_guid": appGUID},
+func (client *Client) UpdateApplicationStart(appGUID string) (resources.Application, Warnings, error) {
+	var responseBody resources.Application
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostApplicationActionStartRequest,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Application{}, nil, err
-	}
 
-	var responseApp Application
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseApp,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responseApp, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // UpdateApplicationStop stops the given application.
-func (client *Client) UpdateApplicationStop(appGUID string) (Application, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostApplicationActionStopRequest,
-		URIParams:   map[string]string{"app_guid": appGUID},
+func (client *Client) UpdateApplicationStop(appGUID string) (resources.Application, Warnings, error) {
+	var responseBody resources.Application
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostApplicationActionStopRequest,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Application{}, nil, err
-	}
 
-	var responseApp Application
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseApp,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responseApp, response.Warnings, err
+	return responseBody, warnings, err
 }

--- a/api/cloudcontroller/ccv3/application_feature.go
+++ b/api/cloudcontroller/ccv3/application_feature.go
@@ -1,0 +1,48 @@
+package ccv3
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
+)
+
+type SSHEnabled struct {
+	Enabled bool
+	Reason  string
+}
+
+func (client *Client) GetAppFeature(appGUID string, featureName string) (resources.ApplicationFeature, Warnings, error) {
+	var responseBody resources.ApplicationFeature
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetApplicationFeaturesRequest,
+		URIParams:    internal.Params{"app_guid": appGUID, "name": featureName},
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}
+
+func (client *Client) GetSSHEnabled(appGUID string) (SSHEnabled, Warnings, error) {
+	var responseBody SSHEnabled
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetSSHEnabled,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}
+
+// UpdateAppFeature enables/disables the ability to ssh for a given application.
+func (client *Client) UpdateAppFeature(appGUID string, enabled bool, featureName string) (Warnings, error) {
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.PatchApplicationFeaturesRequest,
+		RequestBody: struct {
+			Enabled bool `json:"enabled"`
+		}{Enabled: enabled},
+		URIParams: internal.Params{"app_guid": appGUID, "name": featureName},
+	})
+
+	return warnings, err
+}

--- a/api/cloudcontroller/ccv3/build.go
+++ b/api/cloudcontroller/ccv3/build.go
@@ -1,115 +1,33 @@
 package ccv3
 
 import (
-	"bytes"
-	"encoding/json"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
 )
-
-// Build represent the process of staging an application package.
-type Build struct {
-	// CreatedAt is the time with zone when the build was created.
-	CreatedAt string
-	// DropletGUID is the unique identifier for the resulting droplet from the
-	// staging process.
-	DropletGUID string
-	// Error describes errors during the build process.
-	Error string
-	// GUID is the unique build identifier.
-	GUID string
-	// PackageGUID is the unique identifier for package that is the input to the
-	// staging process.
-	PackageGUID string
-	// State is the state of the build.
-	State constant.BuildState
-}
-
-// MarshalJSON converts a Build into a Cloud Controller Application.
-func (b Build) MarshalJSON() ([]byte, error) {
-	var ccBuild struct {
-		Package struct {
-			GUID string `json:"guid"`
-		} `json:"package"`
-	}
-
-	ccBuild.Package.GUID = b.PackageGUID
-
-	return json.Marshal(ccBuild)
-}
-
-// UnmarshalJSON helps unmarshal a Cloud Controller Build response.
-func (b *Build) UnmarshalJSON(data []byte) error {
-	var ccBuild struct {
-		CreatedAt string `json:"created_at,omitempty"`
-		GUID      string `json:"guid,omitempty"`
-		Error     string `json:"error"`
-		Package   struct {
-			GUID string `json:"guid"`
-		} `json:"package"`
-		State   constant.BuildState `json:"state,omitempty"`
-		Droplet struct {
-			GUID string `json:"guid"`
-		} `json:"droplet"`
-	}
-
-	err := cloudcontroller.DecodeJSON(data, &ccBuild)
-	if err != nil {
-		return err
-	}
-
-	b.GUID = ccBuild.GUID
-	b.CreatedAt = ccBuild.CreatedAt
-	b.Error = ccBuild.Error
-	b.PackageGUID = ccBuild.Package.GUID
-	b.State = ccBuild.State
-	b.DropletGUID = ccBuild.Droplet.GUID
-
-	return nil
-}
 
 // CreateBuild creates the given build, requires Package GUID to be set on the
 // build.
-func (client *Client) CreateBuild(build Build) (Build, Warnings, error) {
-	bodyBytes, err := json.Marshal(build)
-	if err != nil {
-		return Build{}, nil, err
-	}
+func (client *Client) CreateBuild(build resources.Build) (resources.Build, Warnings, error) {
+	var responseBody resources.Build
 
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostBuildRequest,
-		Body:        bytes.NewReader(bodyBytes),
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostBuildRequest,
+		RequestBody:  build,
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Build{}, nil, err
-	}
 
-	var responseBuild Build
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseBuild,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responseBuild, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // GetBuild gets the build with the given GUID.
-func (client *Client) GetBuild(guid string) (Build, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetBuildRequest,
-		URIParams:   internal.Params{"build_guid": guid},
+func (client *Client) GetBuild(guid string) (resources.Build, Warnings, error) {
+	var responseBody resources.Build
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetBuildRequest,
+		URIParams:    internal.Params{"build_guid": guid},
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Build{}, nil, err
-	}
 
-	var responseBuild Build
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseBuild,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responseBuild, response.Warnings, err
+	return responseBody, warnings, err
 }

--- a/api/cloudcontroller/ccv3/constant/deployment.go
+++ b/api/cloudcontroller/ccv3/constant/deployment.go
@@ -13,4 +13,43 @@ const (
 
 	// DeploymentDeployed means the deployment is in state 'DEPLOYED'
 	DeploymentDeployed DeploymentState = "DEPLOYED"
+
+	// DeploymentCanceled means the deployment is in state 'CANCELING'
+	DeploymentCanceling DeploymentState = "CANCELING"
+
+	// DeploymentFailing means the deployment is in state 'FAILING'
+	DeploymentFailing DeploymentState = "FAILING"
+
+	// DeploymentFailed means the deployment is in state 'FAILED'
+	DeploymentFailed DeploymentState = "FAILED"
+)
+
+// DeploymentStatusReason describes the status reasons a deployment can have
+type DeploymentStatusReason string
+
+const (
+	// DeploymentStatusReasonDeployed means the deployment's status.value is
+	// 'DEPLOYED'
+	DeploymentStatusReasonDeployed DeploymentStatusReason = "DEPLOYED"
+
+	// DeploymentStatusReasonCanceled means the deployment's status.value is
+	// 'CANCELED'
+	DeploymentStatusReasonCanceled DeploymentStatusReason = "CANCELED"
+
+	// DeploymentStatusReasonSuperseded means the deployment's status.value is
+	// 'SUPERSEDED'
+	DeploymentStatusReasonSuperseded DeploymentStatusReason = "SUPERSEDED"
+)
+
+// DeploymentStatusValue describes the status values a deployment can have
+type DeploymentStatusValue string
+
+const (
+	// DeploymentStatusValueActive means the deployment's status.value is
+	// 'ACTIVE'
+	DeploymentStatusValueActive DeploymentStatusValue = "ACTIVE"
+
+	// DeploymentStatusValueFinalized means the deployment's status.value is
+	// 'FINALIZED'
+	DeploymentStatusValueFinalized DeploymentStatusValue = "FINALIZED"
 )

--- a/api/cloudcontroller/ccv3/constant/environment_variable_group.go
+++ b/api/cloudcontroller/ccv3/constant/environment_variable_group.go
@@ -1,0 +1,8 @@
+package constant
+
+type EnvironmentVariableGroupName string
+
+const (
+	StagingEnvironmentVariableGroup EnvironmentVariableGroupName = "staging"
+	RunningEnvironmentVariableGroup EnvironmentVariableGroupName = "running"
+)

--- a/api/cloudcontroller/ccv3/constant/job.go
+++ b/api/cloudcontroller/ccv3/constant/job.go
@@ -16,9 +16,9 @@ const (
 type JobErrorCode int64
 
 const (
-	JobErrorCodeBuildpackAlreadyExistsForStack     JobErrorCode = 290000
-	JobErrorCodeBuildpackAlreadyExistsWithoutStack JobErrorCode = 290003
-	JobErrorCodeBuildpackStacksDontMatch           JobErrorCode = 390011
-	JobErrorCodeBuildpackStackDoesNotExist         JobErrorCode = 390012
-	JobErrorCodeBuildpackZipInvalid                JobErrorCode = 390013
+	JobErrorCodeBuildpackAlreadyExistsForStack JobErrorCode = 290000
+	JobErrorCodeBuildpackInvalid               JobErrorCode = 290003
+	JobErrorCodeBuildpackStacksDontMatch       JobErrorCode = 390011
+	JobErrorCodeBuildpackStackDoesNotExist     JobErrorCode = 390012
+	JobErrorCodeBuildpackZipInvalid            JobErrorCode = 390013
 )

--- a/api/cloudcontroller/ccv3/deployment.go
+++ b/api/cloudcontroller/ccv3/deployment.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
 )
 
 type Deployment struct {
@@ -46,7 +47,7 @@ func (d *Deployment) UnmarshalJSON(data []byte) error {
 		CreatedAt     string                   `json:"created_at,omitempty"`
 		Relationships Relationships            `json:"relationships,omitempty"`
 		State         constant.DeploymentState `json:"state,omitempty"`
-		Droplet       Droplet                  `json:"droplet,omitempty"`
+		Droplet       resources.Droplet        `json:"droplet,omitempty"`
 	}
 	err := cloudcontroller.DecodeJSON(data, &ccDeployment)
 	if err != nil {

--- a/api/cloudcontroller/ccv3/domain.go
+++ b/api/cloudcontroller/ccv3/domain.go
@@ -1,84 +1,13 @@
 package ccv3
 
 import (
-	"bytes"
 	"encoding/json"
+	"fmt"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
-	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/cli/resources"
 )
-
-type Domain struct {
-	GUID             string         `json:"guid,omitempty"`
-	Name             string         `json:"name"`
-	Internal         types.NullBool `json:"internal,omitempty"`
-	OrganizationGUID string         `json:"orgguid,omitempty"`
-}
-
-func (d Domain) MarshalJSON() ([]byte, error) {
-	type Data struct {
-		GUID string `json:"guid,omitempty"`
-	}
-
-	type OrgData struct {
-		Data Data `json:"data,omitempty"`
-	}
-
-	type OrgRelationship struct {
-		Org OrgData `json:"organization,omitempty"`
-	}
-
-	type ccDomain struct {
-		GUID          string           `json:"guid,omitempty"`
-		Name          string           `json:"name"`
-		Internal      *bool            `json:"internal,omitempty"`
-		Relationships *OrgRelationship `json:"relationships,omitempty"`
-	}
-
-	ccDom := ccDomain{
-		Name: d.Name,
-	}
-
-	if d.Internal.IsSet {
-		ccDom.Internal = &d.Internal.Value
-	}
-
-	if d.GUID != "" {
-		ccDom.GUID = d.GUID
-	}
-
-	if d.OrganizationGUID != "" {
-		ccDom.Relationships = &OrgRelationship{OrgData{Data{GUID: d.OrganizationGUID}}}
-	}
-	return json.Marshal(ccDom)
-}
-
-func (d *Domain) UnmarshalJSON(data []byte) error {
-	var alias struct {
-		GUID          string         `json:"guid,omitempty"`
-		Name          string         `json:"name"`
-		Internal      types.NullBool `json:"internal,omitempty"`
-		Relationships struct {
-			Organization struct {
-				Data struct {
-					GUID string `json:"guid,omitempty"`
-				} `json:"data,omitempty"`
-			} `json:"organization,omitempty"`
-		} `json:"relationships,omitempty"`
-	}
-
-	err := cloudcontroller.DecodeJSON(data, &alias)
-	if err != nil {
-		return err
-	}
-	d.GUID = alias.GUID
-	d.Name = alias.Name
-	d.Internal = alias.Internal
-	d.OrganizationGUID = alias.Relationships.Organization.Data.GUID
-	return nil
-}
 
 type SharedOrgs struct {
 	GUIDs []string
@@ -128,138 +57,119 @@ func (sharedOrgs *SharedOrgs) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (client Client) CreateDomain(domain Domain) (Domain, Warnings, error) {
-	bodyBytes, err := json.Marshal(domain)
-	if err != nil {
-		return Domain{}, nil, err
+// CheckRoute checks whether the route with the given domain GUID, hostname,
+// and path exists in the foundation.
+func (client Client) CheckRoute(domainGUID string, hostname string, path string, port int) (bool, Warnings, error) {
+	var query []Query
+
+	if hostname != "" {
+		query = append(query, Query{Key: HostFilter, Values: []string{hostname}})
 	}
 
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostDomainRequest,
-		Body:        bytes.NewReader(bodyBytes),
+	if path != "" {
+		query = append(query, Query{Key: PathFilter, Values: []string{path}})
+	}
+
+	if port != 0 {
+		query = append(query, Query{Key: PortFilter, Values: []string{fmt.Sprintf("%d", port)}})
+	}
+
+	var responseBody struct {
+		MatchingRoute bool `json:"matching_route"`
+	}
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetDomainRouteReservationsRequest,
+		URIParams:    internal.Params{"domain_guid": domainGUID},
+		Query:        query,
+		ResponseBody: &responseBody,
 	})
 
-	if err != nil {
-		return Domain{}, nil, err
-	}
+	return responseBody.MatchingRoute, warnings, err
+}
 
-	var ccDomain Domain
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &ccDomain,
-	}
+func (client Client) CreateDomain(domain resources.Domain) (resources.Domain, Warnings, error) {
+	var responseBody resources.Domain
 
-	err = client.connection.Make(request, &response)
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostDomainRequest,
+		RequestBody:  domain,
+		ResponseBody: &responseBody,
+	})
 
-	return ccDomain, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 func (client Client) DeleteDomain(domainGUID string) (JobURL, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		URIParams: map[string]string{
-			"domain_guid": domainGUID,
-		},
+	jobURL, warnings, err := client.MakeRequest(RequestParams{
 		RequestName: internal.DeleteDomainRequest,
+		URIParams:   internal.Params{"domain_guid": domainGUID},
 	})
-	if err != nil {
-		return "", nil, err
-	}
 
-	response := cloudcontroller.Response{}
-	err = client.connection.Make(request, &response)
-
-	return JobURL(response.ResourceLocationURL), response.Warnings, err
+	return jobURL, warnings, err
 }
 
-func (client Client) GetDomains(query ...Query) ([]Domain, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetDomainsRequest,
-		Query:       query,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
+// GetDomain returns a domain with the given GUID.
+func (client *Client) GetDomain(domainGUID string) (resources.Domain, Warnings, error) {
+	var responseBody resources.Domain
 
-	var fullDomainsList []Domain
-	warnings, err := client.paginate(request, Domain{}, func(item interface{}) error {
-		if domain, ok := item.(Domain); ok {
-			fullDomainsList = append(fullDomainsList, domain)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   Domain{},
-				Unexpected: item,
-			}
-		}
-		return nil
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetDomainRequest,
+		URIParams:    internal.Params{"domain_guid": domainGUID},
+		ResponseBody: &responseBody,
 	})
 
-	return fullDomainsList, warnings, err
+	return responseBody, warnings, err
 }
 
-func (client Client) GetOrganizationDomains(orgGUID string, query ...Query) ([]Domain, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		URIParams:   internal.Params{"organization_guid": orgGUID},
-		RequestName: internal.GetOrganizationDomainsRequest,
-		Query:       query,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
+func (client Client) GetDomains(query ...Query) ([]resources.Domain, Warnings, error) {
+	var domains []resources.Domain
 
-	var fullDomainsList []Domain
-	warnings, err := client.paginate(request, Domain{}, func(item interface{}) error {
-		if domain, ok := item.(Domain); ok {
-			fullDomainsList = append(fullDomainsList, domain)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   Domain{},
-				Unexpected: item,
-			}
-		}
-		return nil
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetDomainsRequest,
+		Query:        query,
+		ResponseBody: resources.Domain{},
+		AppendToList: func(item interface{}) error {
+			domains = append(domains, item.(resources.Domain))
+			return nil
+		},
 	})
 
-	return fullDomainsList, warnings, err
+	return domains, warnings, err
+}
+
+func (client Client) GetOrganizationDomains(orgGUID string, query ...Query) ([]resources.Domain, Warnings, error) {
+	var domains []resources.Domain
+
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		URIParams:    internal.Params{"organization_guid": orgGUID},
+		RequestName:  internal.GetOrganizationDomainsRequest,
+		Query:        query,
+		ResponseBody: resources.Domain{},
+		AppendToList: func(item interface{}) error {
+			domains = append(domains, item.(resources.Domain))
+			return nil
+		},
+	})
+
+	return domains, warnings, err
 }
 
 func (client Client) SharePrivateDomainToOrgs(domainGuid string, sharedOrgs SharedOrgs) (Warnings, error) {
-	bodyBytes, err := json.Marshal(sharedOrgs)
-
-	if err != nil {
-		return nil, err
-	}
-
-	request, err := client.newHTTPRequest(requestOptions{
-		URIParams:   internal.Params{"domain_guid": domainGuid},
+	_, warnings, err := client.MakeRequest(RequestParams{
 		RequestName: internal.SharePrivateDomainRequest,
-		Body:        bytes.NewReader(bodyBytes),
+		URIParams:   internal.Params{"domain_guid": domainGuid},
+		RequestBody: sharedOrgs,
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	var ccSharedOrgs SharedOrgs
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &ccSharedOrgs,
-	}
-
-	err = client.connection.Make(request, &response)
-
-	return response.Warnings, err
+	return warnings, err
 }
 
 func (client Client) UnsharePrivateDomainFromOrg(domainGuid string, orgGUID string) (Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		URIParams:   internal.Params{"domain_guid": domainGuid, "org_guid": orgGUID},
+	_, warnings, err := client.MakeRequest(RequestParams{
 		RequestName: internal.DeleteSharedOrgFromDomainRequest,
+		URIParams:   internal.Params{"domain_guid": domainGuid, "org_guid": orgGUID},
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	var response cloudcontroller.Response
-
-	err = client.connection.Make(request, &response)
-	return response.Warnings, err
+	return warnings, err
 }

--- a/api/cloudcontroller/ccv3/environment_variables.go
+++ b/api/cloudcontroller/ccv3/environment_variables.go
@@ -1,61 +1,52 @@
 package ccv3
 
 import (
-	"bytes"
-	"encoding/json"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
-	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/cli/resources"
 )
 
 // EnvironmentVariables represents the environment variables that can be set on
 // an application by the user.
-type EnvironmentVariables map[string]types.FilteredString
 
-func (variables EnvironmentVariables) MarshalJSON() ([]byte, error) {
-	ccEnvVars := struct {
-		Var map[string]types.FilteredString `json:"var"`
-	}{
-		Var: variables,
-	}
+// GetEnvironmentVariableGroup gets the values of a particular environment variable group.
+func (client *Client) GetEnvironmentVariableGroup(group constant.EnvironmentVariableGroupName) (resources.EnvironmentVariables, Warnings, error) {
+	var responseBody resources.EnvironmentVariables
 
-	return json.Marshal(ccEnvVars)
-}
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetEnvironmentVariableGroupRequest,
+		URIParams:    internal.Params{"group_name": string(group)},
+		ResponseBody: &responseBody,
+	})
 
-func (variables *EnvironmentVariables) UnmarshalJSON(data []byte) error {
-	var ccEnvVars struct {
-		Var map[string]types.FilteredString `json:"var"`
-	}
-
-	err := cloudcontroller.DecodeJSON(data, &ccEnvVars)
-	*variables = EnvironmentVariables(ccEnvVars.Var)
-
-	return err
+	return responseBody, warnings, err
 }
 
 // UpdateApplicationEnvironmentVariables adds/updates the user provided
 // environment variables on an application. A restart is required for changes
 // to take effect.
-func (client *Client) UpdateApplicationEnvironmentVariables(appGUID string, envVars EnvironmentVariables) (EnvironmentVariables, Warnings, error) {
-	bodyBytes, err := json.Marshal(envVars)
-	if err != nil {
-		return EnvironmentVariables{}, nil, err
-	}
+func (client *Client) UpdateApplicationEnvironmentVariables(appGUID string, envVars resources.EnvironmentVariables) (resources.EnvironmentVariables, Warnings, error) {
+	var responseBody resources.EnvironmentVariables
 
-	request, err := client.newHTTPRequest(requestOptions{
-		URIParams:   internal.Params{"app_guid": appGUID},
-		RequestName: internal.PatchApplicationEnvironmentVariablesRequest,
-		Body:        bytes.NewReader(bodyBytes),
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PatchApplicationEnvironmentVariablesRequest,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		RequestBody:  envVars,
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return EnvironmentVariables{}, nil, err
-	}
 
-	var responseEnvVars EnvironmentVariables
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseEnvVars,
-	}
-	err = client.connection.Make(request, &response)
-	return responseEnvVars, response.Warnings, err
+	return responseBody, warnings, err
+}
+
+func (client *Client) UpdateEnvironmentVariableGroup(group constant.EnvironmentVariableGroupName, envVars resources.EnvironmentVariables) (resources.EnvironmentVariables, Warnings, error) {
+	var responseBody resources.EnvironmentVariables
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PatchEnvironmentVariableGroupRequest,
+		URIParams:    internal.Params{"group_name": string(group)},
+		RequestBody:  envVars,
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
 }

--- a/api/cloudcontroller/ccv3/included_resource.go
+++ b/api/cloudcontroller/ccv3/included_resource.go
@@ -8,4 +8,5 @@ type IncludedResources struct {
 	Spaces           []resources.Space           `json:"spaces,omitempty"`
 	ServiceOfferings []resources.ServiceOffering `json:"service_offerings,omitempty"`
 	ServiceBrokers   []resources.ServiceBroker   `json:"service_brokers,omitempty"`
+	Apps             []resources.Application     `json:"apps,omitempty"`
 }

--- a/api/cloudcontroller/ccv3/internal/api_resources.go
+++ b/api/cloudcontroller/ccv3/internal/api_resources.go
@@ -20,4 +20,6 @@ const (
 	TasksResource             = "tasks"
 
 	ServiceOfferingsResource = "service_offerings"
+
+	ServicePlansResource = "service_plans"
 )

--- a/api/cloudcontroller/ccv3/internal/api_resources.go
+++ b/api/cloudcontroller/ccv3/internal/api_resources.go
@@ -18,4 +18,6 @@ const (
 	SpacesResource            = "spaces"
 	StacksResource            = "stacks"
 	TasksResource             = "tasks"
+
+	ServiceOfferingsResource = "service_offerings"
 )

--- a/api/cloudcontroller/ccv3/internal/api_resources.go
+++ b/api/cloudcontroller/ccv3/internal/api_resources.go
@@ -22,4 +22,6 @@ const (
 	ServiceOfferingsResource = "service_offerings"
 
 	ServicePlansResource = "service_plans"
+
+	RoutesResource = "routes"
 )

--- a/api/cloudcontroller/ccv3/internal/api_resources.go
+++ b/api/cloudcontroller/ccv3/internal/api_resources.go
@@ -24,4 +24,7 @@ const (
 	ServicePlansResource = "service_plans"
 
 	RoutesResource = "routes"
+
+	//v3 service credential binding
+	ServiceCredentialBindingsResource = "service_credential_bindings"
 )

--- a/api/cloudcontroller/ccv3/internal/api_resources.go
+++ b/api/cloudcontroller/ccv3/internal/api_resources.go
@@ -27,4 +27,7 @@ const (
 
 	//v3 service credential binding
 	ServiceCredentialBindingsResource = "service_credential_bindings"
+
+	//v3 environment variable
+	EnvironmentVariableGroupsResource = "environment_variable_groups"
 )

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -138,6 +138,11 @@ const (
 	// v3 domain add missing endpoints
 	GetDomainRouteReservationsRequest = "GetDomainRouteReservations"
 	GetDomainRequest                  = "GetDomain"
+
+	// v3 space add missing
+	PostSpaceRequest   = "PostSpace"
+	DeleteSpaceRequest = "DeleteSpace"
+	PatchSpaceRequest  = "PatchSpace"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -192,6 +197,11 @@ var APIRoutes = []Route{
 	// v3 domain add missing
 	{Resource: DomainsResource, Path: "/:domain_guid/route_reservations", Method: http.MethodGet, Name: GetDomainRouteReservationsRequest},
 	{Resource: DomainsResource, Path: "/:domain_guid", Method: http.MethodGet, Name: GetDomainRequest},
+
+	// v3 space add missing
+	{Resource: SpacesResource, Path: "/", Method: http.MethodPost, Name: PostSpaceRequest},
+	{Resource: SpacesResource, Path: "/:space_guid", Method: http.MethodDelete, Name: DeleteSpaceRequest},
+	{Resource: SpacesResource, Path: "/:space_guid", Method: http.MethodPatch, Name: PatchSpaceRequest},
 
 	{Resource: ServicePlansResource, Path: "/", Method: http.MethodGet, Name: GetServicePlansRequest},
 

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -112,6 +112,15 @@ const (
 	GetServiceCredentialBindingsRequest       = "GetServiceCredentialBindings"
 	DeleteServiceCredentialBindingRequest     = "DeleteServiceCredentialBinding"
 	GetServiceCredentialBindingDetailsRequest = "GetServiceCredentialBindingDetails"
+
+	// service_instance
+	GetServiceInstanceParametersRequest                = "GetServiceInstanceParameters"
+	GetServiceInstanceCredentialsRequest               = "GetServiceInstanceCredentails"
+	PostServiceInstanceRequest                         = "PostServiceInstance"
+	PatchServiceInstanceRequest                        = "PatchServiceInstance"
+	DeleteServiceInstanceRequest                       = "DeleteServiceInstance"
+	GetServiceInstanceRelationshipsSharedSpacesRequest = "GetServiceInstanceRelationshipSharedSpacesRequest"
+	GetServiceInstanceSharedSpacesUsageSummaryRequest  = "GetServiceInstanceSharedSpacesUsageSummaryRequest"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -121,13 +130,24 @@ var APIRoutes = []Route{
 	{Resource: PackagesResource, Path: "/:package_guid/droplets", Method: http.MethodGet, Name: GetPackageDropletsRequest},
 	{Resource: DropletsResource, Path: "/:droplet_guid/upload", Method: http.MethodPost, Name: PostDropletBitsRequest},
 	{Resource: DropletsResource, Path: "/:droplet_guid/download", Method: http.MethodGet, Name: GetDropletBitsRequest},
+
 	// v3 package
 	{Resource: PackagesResource, Path: "/:package_guid/upload", Method: http.MethodPost, Name: PostPackageBitsRequest},
+
 	// v3 service credential binding
 	{Resource: ServiceCredentialBindingsResource, Path: "/", Method: http.MethodGet, Name: GetServiceCredentialBindingsRequest},
 	{Resource: ServiceCredentialBindingsResource, Path: "/:service_credential_binding_guid/details", Method: http.MethodGet, Name: GetServiceCredentialBindingDetailsRequest},
 	{Resource: ServiceCredentialBindingsResource, Path: "/:service_credential_binding_guid", Method: http.MethodDelete, Name: DeleteServiceCredentialBindingRequest},
 	{Resource: ServiceCredentialBindingsResource, Path: "/", Method: http.MethodPost, Name: PostServiceCredentialBindingRequest},
+
+	// v3 service instance
+	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid/parameters", Method: http.MethodGet, Name: GetServiceInstanceParametersRequest},
+	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid/credentials", Method: http.MethodGet, Name: GetServiceInstanceCredentialsRequest},
+	{Resource: ServiceInstancesResource, Path: "/", Method: http.MethodPost, Name: PostServiceInstanceRequest},
+	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid", Method: http.MethodPatch, Name: PatchServiceInstanceRequest},
+	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid", Method: http.MethodDelete, Name: DeleteServiceInstanceRequest},
+	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid/relationships/shared_spaces", Method: http.MethodGet, Name: GetServiceInstanceRelationshipsSharedSpacesRequest},
+	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid/relationships/shared_spaces/usage_summary", Method: http.MethodGet, Name: GetServiceInstanceSharedSpacesUsageSummaryRequest},
 
 	{Resource: RoutesResource, Path: "/:route_guid/destinations/:destination_guid", Method: http.MethodDelete, Name: UnmapRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid/destinations", Method: http.MethodPost, Name: MapRouteRequest},

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -106,6 +106,12 @@ const (
 
 	// v3 package
 	PostPackageBitsRequest = "PostPackageBits"
+
+	// v3 service credential binding
+	PostServiceCredentialBindingRequest       = "PostServiceCredentialBinding"
+	GetServiceCredentialBindingsRequest       = "GetServiceCredentialBindings"
+	DeleteServiceCredentialBindingRequest     = "DeleteServiceCredentialBinding"
+	GetServiceCredentialBindingDetailsRequest = "GetServiceCredentialBindingDetails"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -117,6 +123,11 @@ var APIRoutes = []Route{
 	{Resource: DropletsResource, Path: "/:droplet_guid/download", Method: http.MethodGet, Name: GetDropletBitsRequest},
 	// v3 package
 	{Resource: PackagesResource, Path: "/:package_guid/upload", Method: http.MethodPost, Name: PostPackageBitsRequest},
+	// v3 service credential binding
+	{Resource: ServiceCredentialBindingsResource, Path: "/", Method: http.MethodGet, Name: GetServiceCredentialBindingsRequest},
+	{Resource: ServiceCredentialBindingsResource, Path: "/:service_credential_binding_guid/details", Method: http.MethodGet, Name: GetServiceCredentialBindingDetailsRequest},
+	{Resource: ServiceCredentialBindingsResource, Path: "/:service_credential_binding_guid", Method: http.MethodDelete, Name: DeleteServiceCredentialBindingRequest},
+	{Resource: ServiceCredentialBindingsResource, Path: "/", Method: http.MethodPost, Name: PostServiceCredentialBindingRequest},
 
 	{Resource: RoutesResource, Path: "/:route_guid/destinations/:destination_guid", Method: http.MethodDelete, Name: UnmapRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid/destinations", Method: http.MethodPost, Name: MapRouteRequest},

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -103,6 +103,9 @@ const (
 	GetPackageDropletsRequest = "GetPackageDroplets"
 	PostDropletBitsRequest    = "PostDropletBits"
 	GetDropletBitsRequest     = "GetDropletBits"
+
+	// v3 package
+	PostPackageBitsRequest = "PostPackageBits"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -112,6 +115,8 @@ var APIRoutes = []Route{
 	{Resource: PackagesResource, Path: "/:package_guid/droplets", Method: http.MethodGet, Name: GetPackageDropletsRequest},
 	{Resource: DropletsResource, Path: "/:droplet_guid/upload", Method: http.MethodPost, Name: PostDropletBitsRequest},
 	{Resource: DropletsResource, Path: "/:droplet_guid/download", Method: http.MethodGet, Name: GetDropletBitsRequest},
+	// v3 package
+	{Resource: PackagesResource, Path: "/:package_guid/upload", Method: http.MethodPost, Name: PostPackageBitsRequest},
 
 	{Resource: RoutesResource, Path: "/:route_guid/destinations/:destination_guid", Method: http.MethodDelete, Name: UnmapRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid/destinations", Method: http.MethodPost, Name: MapRouteRequest},

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -125,6 +125,11 @@ const (
 	// v3 process add missing endpoints
 	GetProcessRequest   = "GetProcess"
 	GetProcessesRequest = "GetProcesses"
+
+	// v3 application feature
+	GetApplicationFeaturesRequest   = "GetApplicationFeatures"
+	GetSSHEnabled                   = "GetSSHEnabled"
+	PatchApplicationFeaturesRequest = "PatchApplicationFeatures"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -166,6 +171,11 @@ var APIRoutes = []Route{
 	{Resource: RoutesResource, Path: "/", Method: http.MethodPost, Name: PostRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid", Method: http.MethodDelete, Name: DeleteRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid", Method: http.MethodPatch, Name: PatchRouteRequest},
+
+	// v3 application feature
+	{Resource: AppsResource, Path: "/:app_guid/ssh_enabled", Method: http.MethodGet, Name: GetSSHEnabled},
+	{Resource: AppsResource, Path: "/:app_guid/features/:name", Method: http.MethodGet, Name: GetApplicationFeaturesRequest},
+	{Resource: AppsResource, Path: "/:app_guid/features/:name", Method: http.MethodPatch, Name: PatchApplicationFeaturesRequest},
 
 	{Resource: ServicePlansResource, Path: "/", Method: http.MethodGet, Name: GetServicePlansRequest},
 

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -86,10 +86,31 @@ const (
 	DeleteServiceOfferingRequest = "DeleteServiceOffering"
 
 	GetServicePlansRequest = "GetServicePlans"
+
+	PostRouteRequest   = "PostRoute"
+	DeleteRouteRequest = "DeleteRouteRequest"
+	PatchRouteRequest  = "PatchRoute"
+
+	DeleteOrphanedRoutesRequest = "DeleteOrphanedRoutes"
+	GetApplicationRoutesRequest = "GetApplicationRoutes"
+	GetRouteDestinationsRequest = "GetRouteDestinations"
+	GetRoutesRequest            = "GetRoutes"
+	MapRouteRequest             = "MapRoute"
+	UnmapRouteRequest           = "UnmapRoute"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
 var APIRoutes = []Route{
+	{Resource: RoutesResource, Path: "/:route_guid/destinations/:destination_guid", Method: http.MethodDelete, Name: UnmapRouteRequest},
+	{Resource: RoutesResource, Path: "/:route_guid/destinations", Method: http.MethodPost, Name: MapRouteRequest},
+	{Resource: RoutesResource, Path: "/", Method: http.MethodGet, Name: GetRoutesRequest},
+	{Resource: RoutesResource, Path: "/:route_guid/destinations", Method: http.MethodGet, Name: GetRouteDestinationsRequest},
+	{Resource: AppsResource, Path: "/:app_guid/routes", Method: http.MethodGet, Name: GetApplicationRoutesRequest},
+	{Resource: SpacesResource, Path: "/:space_guid/routes", Method: http.MethodDelete, Name: DeleteOrphanedRoutesRequest},
+	{Resource: RoutesResource, Path: "/", Method: http.MethodPost, Name: PostRouteRequest},
+	{Resource: RoutesResource, Path: "/:route_guid", Method: http.MethodDelete, Name: DeleteRouteRequest},
+	{Resource: RoutesResource, Path: "/:route_guid", Method: http.MethodPatch, Name: PatchRouteRequest},
+
 	{Resource: ServicePlansResource, Path: "/", Method: http.MethodGet, Name: GetServicePlansRequest},
 
 	{Resource: ServiceOfferingsResource, Path: "/", Method: http.MethodGet, Name: GetServiceOfferingsRequest},

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -134,6 +134,10 @@ const (
 	// v3 environment variable
 	GetEnvironmentVariableGroupRequest   = "GetEnvironmentVariableGroup"
 	PatchEnvironmentVariableGroupRequest = "PatchEnvironmentVariableGroup"
+
+	// v3 domain add missing endpoints
+	GetDomainRouteReservationsRequest = "GetDomainRouteReservations"
+	GetDomainRequest                  = "GetDomain"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -184,6 +188,10 @@ var APIRoutes = []Route{
 	// v3 environment varirable
 	{Resource: EnvironmentVariableGroupsResource, Path: "/:group_name", Method: http.MethodGet, Name: GetEnvironmentVariableGroupRequest},
 	{Resource: EnvironmentVariableGroupsResource, Path: "/:group_name", Method: http.MethodPatch, Name: PatchEnvironmentVariableGroupRequest},
+
+	// v3 domain add missing
+	{Resource: DomainsResource, Path: "/:domain_guid/route_reservations", Method: http.MethodGet, Name: GetDomainRouteReservationsRequest},
+	{Resource: DomainsResource, Path: "/:domain_guid", Method: http.MethodGet, Name: GetDomainRequest},
 
 	{Resource: ServicePlansResource, Path: "/", Method: http.MethodGet, Name: GetServicePlansRequest},
 

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -121,6 +121,10 @@ const (
 	DeleteServiceInstanceRequest                       = "DeleteServiceInstance"
 	GetServiceInstanceRelationshipsSharedSpacesRequest = "GetServiceInstanceRelationshipSharedSpacesRequest"
 	GetServiceInstanceSharedSpacesUsageSummaryRequest  = "GetServiceInstanceSharedSpacesUsageSummaryRequest"
+
+	// v3 process add missing endpoints
+	GetProcessRequest   = "GetProcess"
+	GetProcessesRequest = "GetProcesses"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -148,6 +152,10 @@ var APIRoutes = []Route{
 	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid", Method: http.MethodDelete, Name: DeleteServiceInstanceRequest},
 	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid/relationships/shared_spaces", Method: http.MethodGet, Name: GetServiceInstanceRelationshipsSharedSpacesRequest},
 	{Resource: ServiceInstancesResource, Path: "/:service_instance_guid/relationships/shared_spaces/usage_summary", Method: http.MethodGet, Name: GetServiceInstanceSharedSpacesUsageSummaryRequest},
+
+	// v3 process add missing endpoints
+	{Resource: ProcessesResource, Path: "/", Method: http.MethodGet, Name: GetProcessesRequest},
+	{Resource: ProcessesResource, Path: "/:process_guid", Method: http.MethodGet, Name: GetProcessRequest},
 
 	{Resource: RoutesResource, Path: "/:route_guid/destinations/:destination_guid", Method: http.MethodDelete, Name: UnmapRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid/destinations", Method: http.MethodPost, Name: MapRouteRequest},

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -97,10 +97,22 @@ const (
 	GetRoutesRequest            = "GetRoutes"
 	MapRouteRequest             = "MapRoute"
 	UnmapRouteRequest           = "UnmapRoute"
+
+	// v3 droplet
+	PostDropletRequest        = "PostDroplet"
+	GetPackageDropletsRequest = "GetPackageDroplets"
+	PostDropletBitsRequest    = "PostDropletBits"
+	GetDropletBitsRequest     = "GetDropletBits"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
 var APIRoutes = []Route{
+	// v3 droplet
+	{Resource: DropletsResource, Path: "/", Method: http.MethodPost, Name: PostDropletRequest},
+	{Resource: PackagesResource, Path: "/:package_guid/droplets", Method: http.MethodGet, Name: GetPackageDropletsRequest},
+	{Resource: DropletsResource, Path: "/:droplet_guid/upload", Method: http.MethodPost, Name: PostDropletBitsRequest},
+	{Resource: DropletsResource, Path: "/:droplet_guid/download", Method: http.MethodGet, Name: GetDropletBitsRequest},
+
 	{Resource: RoutesResource, Path: "/:route_guid/destinations/:destination_guid", Method: http.MethodDelete, Name: UnmapRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid/destinations", Method: http.MethodPost, Name: MapRouteRequest},
 	{Resource: RoutesResource, Path: "/", Method: http.MethodGet, Name: GetRoutesRequest},

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -81,10 +81,16 @@ const (
 	DeleteOrganizationRequest = "DeleteOrganization"
 	PostOrganizationRequest   = "PostOrganization"
 	GetDefaultDomainRequest   = "GetDefaultDomain"
+
+	GetServiceOfferingsRequest   = "GetServiceOfferings"
+	DeleteServiceOfferingRequest = "DeleteServiceOffering"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
 var APIRoutes = []Route{
+	{Resource: ServiceOfferingsResource, Path: "/", Method: http.MethodGet, Name: GetServiceOfferingsRequest},
+	{Resource: ServiceOfferingsResource, Path: "/:service_offering_guid", Method: http.MethodDelete, Name: DeleteServiceOfferingRequest},
+
 	{Resource: OrgsResource, Path: "/", Method: http.MethodGet, Name: GetOrganizationsRequest},
 	{Resource: OrgsResource, Path: "/:organization_guid/", Method: http.MethodDelete, Name: DeleteOrganizationRequest},
 	{Resource: OrgsResource, Path: "/", Method: http.MethodPost, Name: PostOrganizationRequest},

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -130,6 +130,10 @@ const (
 	GetApplicationFeaturesRequest   = "GetApplicationFeatures"
 	GetSSHEnabled                   = "GetSSHEnabled"
 	PatchApplicationFeaturesRequest = "PatchApplicationFeatures"
+
+	// v3 environment variable
+	GetEnvironmentVariableGroupRequest   = "GetEnvironmentVariableGroup"
+	PatchEnvironmentVariableGroupRequest = "PatchEnvironmentVariableGroup"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
@@ -176,6 +180,10 @@ var APIRoutes = []Route{
 	{Resource: AppsResource, Path: "/:app_guid/ssh_enabled", Method: http.MethodGet, Name: GetSSHEnabled},
 	{Resource: AppsResource, Path: "/:app_guid/features/:name", Method: http.MethodGet, Name: GetApplicationFeaturesRequest},
 	{Resource: AppsResource, Path: "/:app_guid/features/:name", Method: http.MethodPatch, Name: PatchApplicationFeaturesRequest},
+
+	// v3 environment varirable
+	{Resource: EnvironmentVariableGroupsResource, Path: "/:group_name", Method: http.MethodGet, Name: GetEnvironmentVariableGroupRequest},
+	{Resource: EnvironmentVariableGroupsResource, Path: "/:group_name", Method: http.MethodPatch, Name: PatchEnvironmentVariableGroupRequest},
 
 	{Resource: ServicePlansResource, Path: "/", Method: http.MethodGet, Name: GetServicePlansRequest},
 

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -84,10 +84,14 @@ const (
 
 	GetServiceOfferingsRequest   = "GetServiceOfferings"
 	DeleteServiceOfferingRequest = "DeleteServiceOffering"
+
+	GetServicePlansRequest = "GetServicePlans"
 )
 
 // APIRoutes is a list of routes used by the router to construct request URLs.
 var APIRoutes = []Route{
+	{Resource: ServicePlansResource, Path: "/", Method: http.MethodGet, Name: GetServicePlansRequest},
+
 	{Resource: ServiceOfferingsResource, Path: "/", Method: http.MethodGet, Name: GetServiceOfferingsRequest},
 	{Resource: ServiceOfferingsResource, Path: "/:service_offering_guid", Method: http.MethodDelete, Name: DeleteServiceOfferingRequest},
 

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -203,6 +203,9 @@ var APIRoutes = []Route{
 	{Resource: SpacesResource, Path: "/:space_guid", Method: http.MethodDelete, Name: DeleteSpaceRequest},
 	{Resource: SpacesResource, Path: "/:space_guid", Method: http.MethodPatch, Name: PatchSpaceRequest},
 
+	// v3 org add missing
+	{Resource: OrgsResource, Path: "/:organization_guid", Method: http.MethodGet, Name: GetOrganizationRequest},
+
 	{Resource: ServicePlansResource, Path: "/", Method: http.MethodGet, Name: GetServicePlansRequest},
 
 	{Resource: ServiceOfferingsResource, Path: "/", Method: http.MethodGet, Name: GetServiceOfferingsRequest},

--- a/api/cloudcontroller/ccv3/isolation_segment.go
+++ b/api/cloudcontroller/ccv3/isolation_segment.go
@@ -1,110 +1,64 @@
 package ccv3
 
 import (
-	"bytes"
-	"encoding/json"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
 )
-
-// IsolationSegment represents a Cloud Controller Isolation Segment.
-type IsolationSegment struct {
-	//GUID is the unique ID of the isolation segment.
-	GUID string `json:"guid,omitempty"`
-	//Name is the name of the isolation segment.
-	Name string `json:"name"`
-}
 
 // CreateIsolationSegment will create an Isolation Segment on the Cloud
 // Controller. Note: This will not validate that the placement tag exists in
 // the diego cluster.
-func (client *Client) CreateIsolationSegment(isolationSegment IsolationSegment) (IsolationSegment, Warnings, error) {
-	body, err := json.Marshal(isolationSegment)
-	if err != nil {
-		return IsolationSegment{}, nil, err
-	}
+func (client *Client) CreateIsolationSegment(isolationSegment resources.IsolationSegment) (resources.IsolationSegment, Warnings, error) {
+	var responseBody resources.IsolationSegment
 
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostIsolationSegmentsRequest,
-		Body:        bytes.NewReader(body),
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostIsolationSegmentsRequest,
+		RequestBody:  isolationSegment,
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return IsolationSegment{}, nil, err
-	}
 
-	var responseIsolationSegment IsolationSegment
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseIsolationSegment,
-	}
-
-	err = client.connection.Make(request, &response)
-	return responseIsolationSegment, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // DeleteIsolationSegment removes an isolation segment from the cloud
 // controller. Note: This will only remove it from the cloud controller
 // database. It will not remove it from diego.
 func (client *Client) DeleteIsolationSegment(guid string) (Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
+	_, warnings, err := client.MakeRequest(RequestParams{
 		RequestName: internal.DeleteIsolationSegmentRequest,
-		URIParams:   map[string]string{"isolation_segment_guid": guid},
+		URIParams:   internal.Params{"isolation_segment_guid": guid},
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	var response cloudcontroller.Response
-	err = client.connection.Make(request, &response)
-	return response.Warnings, err
+	return warnings, err
 }
 
 // GetIsolationSegment returns back the requested isolation segment that
 // matches the GUID.
-func (client *Client) GetIsolationSegment(guid string) (IsolationSegment, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetIsolationSegmentRequest,
-		URIParams:   map[string]string{"isolation_segment_guid": guid},
+func (client *Client) GetIsolationSegment(guid string) (resources.IsolationSegment, Warnings, error) {
+	var responseBody resources.IsolationSegment
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetIsolationSegmentRequest,
+		URIParams:    internal.Params{"isolation_segment_guid": guid},
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return IsolationSegment{}, nil, err
-	}
-	var isolationSegment IsolationSegment
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &isolationSegment,
-	}
 
-	err = client.connection.Make(request, &response)
-	if err != nil {
-		return IsolationSegment{}, response.Warnings, err
-	}
-
-	return isolationSegment, response.Warnings, nil
+	return responseBody, warnings, err
 }
 
 // GetIsolationSegments lists isolation segments with optional filters.
-func (client *Client) GetIsolationSegments(query ...Query) ([]IsolationSegment, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetIsolationSegmentsRequest,
-		Query:       query,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
+func (client *Client) GetIsolationSegments(query ...Query) ([]resources.IsolationSegment, Warnings, error) {
+	var isolationSegments []resources.IsolationSegment
 
-	var fullIsolationSegmentsList []IsolationSegment
-	warnings, err := client.paginate(request, IsolationSegment{}, func(item interface{}) error {
-		if isolationSegment, ok := item.(IsolationSegment); ok {
-			fullIsolationSegmentsList = append(fullIsolationSegmentsList, isolationSegment)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   IsolationSegment{},
-				Unexpected: item,
-			}
-		}
-		return nil
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetIsolationSegmentsRequest,
+		Query:        query,
+		ResponseBody: resources.IsolationSegment{},
+		AppendToList: func(item interface{}) error {
+			isolationSegments = append(isolationSegments, item.(resources.IsolationSegment))
+			return nil
+		},
 	})
 
-	return fullIsolationSegmentsList, warnings, err
+	return isolationSegments, warnings, err
 }

--- a/api/cloudcontroller/ccv3/package.go
+++ b/api/cloudcontroller/ccv3/package.go
@@ -12,175 +12,53 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
 )
 
-//go:generate counterfeiter io.Reader
-
-// Package represents a Cloud Controller V3 Package.
-type Package struct {
-	// CreatedAt is the time with zone when the object was created.
-	CreatedAt string
-
-	// DockerImage is the registry address of the docker image.
-	DockerImage string
-
-	// DockerPassword is the password for the docker image's registry.
-	DockerPassword string
-
-	// DockerUsername is the username for the docker image's registry.
-	DockerUsername string
-
-	// GUID is the unique identifier of the package.
-	GUID string
-
-	// Links are links to related resources.
-	Links APILinks
-
-	// Relationships are a list of relationships to other resources.
-	Relationships Relationships
-
-	// State is the state of the package.
-	State constant.PackageState
-
-	// Type is the package type.
-	Type constant.PackageType
-}
-
-// MarshalJSON converts a Package into a Cloud Controller Package.
-func (p Package) MarshalJSON() ([]byte, error) {
-	type ccPackageData struct {
-		Image    string `json:"image,omitempty"`
-		Username string `json:"username,omitempty"`
-		Password string `json:"password,omitempty"`
-	}
-	var ccPackage struct {
-		GUID          string                `json:"guid,omitempty"`
-		CreatedAt     string                `json:"created_at,omitempty"`
-		Links         APILinks              `json:"links,omitempty"`
-		Relationships Relationships         `json:"relationships,omitempty"`
-		State         constant.PackageState `json:"state,omitempty"`
-		Type          constant.PackageType  `json:"type,omitempty"`
-		Data          *ccPackageData        `json:"data,omitempty"`
-	}
-
-	ccPackage.GUID = p.GUID
-	ccPackage.CreatedAt = p.CreatedAt
-	ccPackage.Links = p.Links
-	ccPackage.Relationships = p.Relationships
-	ccPackage.State = p.State
-	ccPackage.Type = p.Type
-	if p.DockerImage != "" {
-		ccPackage.Data = &ccPackageData{
-			Image:    p.DockerImage,
-			Username: p.DockerUsername,
-			Password: p.DockerPassword,
-		}
-	}
-
-	return json.Marshal(ccPackage)
-}
-
-// UnmarshalJSON helps unmarshal a Cloud Controller Package response.
-func (p *Package) UnmarshalJSON(data []byte) error {
-	var ccPackage struct {
-		GUID          string                `json:"guid,omitempty"`
-		CreatedAt     string                `json:"created_at,omitempty"`
-		Links         APILinks              `json:"links,omitempty"`
-		Relationships Relationships         `json:"relationships,omitempty"`
-		State         constant.PackageState `json:"state,omitempty"`
-		Type          constant.PackageType  `json:"type,omitempty"`
-		Data          struct {
-			Image    string `json:"image"`
-			Username string `json:"username"`
-			Password string `json:"password"`
-		} `json:"data"`
-	}
-	err := cloudcontroller.DecodeJSON(data, &ccPackage)
-	if err != nil {
-		return err
-	}
-
-	p.GUID = ccPackage.GUID
-	p.CreatedAt = ccPackage.CreatedAt
-	p.Links = ccPackage.Links
-	p.Relationships = ccPackage.Relationships
-	p.State = ccPackage.State
-	p.Type = ccPackage.Type
-	p.DockerImage = ccPackage.Data.Image
-	p.DockerUsername = ccPackage.Data.Username
-	p.DockerPassword = ccPackage.Data.Password
-
-	return nil
-}
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 io.Reader
 
 // CreatePackage creates a package with the given settings, Type and the
 // ApplicationRelationship must be set.
-func (client *Client) CreatePackage(pkg Package) (Package, Warnings, error) {
-	bodyBytes, err := json.Marshal(pkg)
-	if err != nil {
-		return Package{}, nil, err
-	}
+func (client *Client) CreatePackage(pkg resources.Package) (resources.Package, Warnings, error) {
+	var responseBody resources.Package
 
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostPackageRequest,
-		Body:        bytes.NewReader(bodyBytes),
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostPackageRequest,
+		RequestBody:  pkg,
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Package{}, nil, err
-	}
 
-	var responsePackage Package
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responsePackage,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responsePackage, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // GetPackage returns the package with the given GUID.
-func (client *Client) GetPackage(packageGUID string) (Package, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetPackageRequest,
-		URIParams:   internal.Params{"package_guid": packageGUID},
+func (client *Client) GetPackage(packageGUID string) (resources.Package, Warnings, error) {
+	var responseBody resources.Package
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetPackageRequest,
+		URIParams:    internal.Params{"package_guid": packageGUID},
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Package{}, nil, err
-	}
 
-	var responsePackage Package
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responsePackage,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responsePackage, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // GetPackages returns the list of packages.
-func (client *Client) GetPackages(query ...Query) ([]Package, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetPackagesRequest,
-		Query:       query,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
+func (client *Client) GetPackages(query ...Query) ([]resources.Package, Warnings, error) {
+	var packages []resources.Package
 
-	var fullPackagesList []Package
-	warnings, err := client.paginate(request, Package{}, func(item interface{}) error {
-		if pkg, ok := item.(Package); ok {
-			fullPackagesList = append(fullPackagesList, pkg)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   Package{},
-				Unexpected: item,
-			}
-		}
-		return nil
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetPackagesRequest,
+		Query:        query,
+		ResponseBody: resources.Package{},
+		AppendToList: func(item interface{}) error {
+			packages = append(packages, item.(resources.Package))
+			return nil
+		},
 	})
 
-	return fullPackagesList, warnings, err
+	return packages, warnings, err
 }
 
 // UploadBitsPackage uploads the newResources and a list of existing resources
@@ -192,54 +70,55 @@ func (client *Client) GetPackages(query ...Query) ([]Package, Warnings, error) {
 //
 // Note: In order to determine if package creation is successful, poll the
 // Package's state field for more information.
-func (client *Client) UploadBitsPackage(pkg Package, matchedResources []Resource, newResources io.Reader, newResourcesLength int64) (Package, Warnings, error) {
-	link, ok := pkg.Links["upload"]
-	if !ok {
-		return Package{}, nil, ccerror.UploadLinkNotFoundError{PackageGUID: pkg.GUID}
-	}
-
+func (client *Client) UploadBitsPackage(pkg resources.Package, matchedResources []Resource, newResources io.Reader, newResourcesLength int64) (resources.Package, Warnings, error) {
 	if matchedResources == nil {
-		return Package{}, nil, ccerror.NilObjectError{Object: "matchedResources"}
+		return resources.Package{}, nil, ccerror.NilObjectError{Object: "matchedResources"}
 	}
 
 	if newResources == nil {
-		return client.uploadExistingResourcesOnly(link, matchedResources)
+		return client.uploadExistingResourcesOnly(pkg.GUID, matchedResources)
 	}
 
-	return client.uploadNewAndExistingResources(link, matchedResources, newResources, newResourcesLength)
+	return client.uploadNewAndExistingResources(pkg.GUID, matchedResources, newResources, newResourcesLength)
 }
 
 // UploadPackage uploads a file to a given package's Upload resource. Note:
 // fileToUpload is read entirely into memory prior to sending data to CC.
-func (client *Client) UploadPackage(pkg Package, fileToUpload string) (Package, Warnings, error) {
-	link, ok := pkg.Links["upload"]
-	if !ok {
-		return Package{}, nil, ccerror.UploadLinkNotFoundError{PackageGUID: pkg.GUID}
-	}
-
-	body, contentType, err := client.createUploadStream(fileToUpload, "bits")
+func (client *Client) UploadPackage(pkg resources.Package, fileToUpload string) (resources.Package, Warnings, error) {
+	body, contentType, err := client.createUploadBuffer(fileToUpload, "bits")
 	if err != nil {
-		return Package{}, nil, err
+		return resources.Package{}, nil, err
 	}
 
-	request, err := client.newHTTPRequest(requestOptions{
-		URL:    link.HREF,
-		Method: link.Method,
-		Body:   body,
+	responsePackage := resources.Package{}
+	_, warnings, err := client.MakeRequestSendRaw(
+		internal.PostPackageBitsRequest,
+		internal.Params{"package_guid": pkg.GUID},
+		body.Bytes(),
+		contentType,
+		&responsePackage,
+	)
+
+	return responsePackage, warnings, err
+}
+
+// CopyPackage copies a package from a source package to a destination package
+// Note: source app guid is in URL; dest app guid is in body
+func (client *Client) CopyPackage(sourcePkgGUID string, targetAppGUID string) (resources.Package, Warnings, error) {
+	var targetPackage resources.Package
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.PostPackageRequest,
+		Query:       []Query{{Key: SourceGUID, Values: []string{sourcePkgGUID}}},
+		RequestBody: map[string]resources.Relationships{
+			"relationships": {
+				constant.RelationshipTypeApplication: resources.Relationship{GUID: targetAppGUID},
+			},
+		},
+		ResponseBody: &targetPackage,
 	})
-	if err != nil {
-		return Package{}, nil, err
-	}
 
-	request.Header.Set("Content-Type", contentType)
-
-	var responsePackage Package
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responsePackage,
-	}
-	err = client.connection.Make(request, &response)
-
-	return responsePackage, response.Warnings, err
+	return targetPackage, warnings, err
 }
 
 func (client *Client) calculateAppBitsRequestSize(matchedResources []Resource, newResourcesLength int64) (int64, error) {
@@ -311,141 +190,77 @@ func (client *Client) createMultipartBodyAndHeaderForAppBits(matchedResources []
 	return form.FormDataContentType(), writerOutput, writeErrors
 }
 
-func (*Client) createUploadStream(path string, paramName string) (io.ReadSeeker, string, error) {
+func (*Client) createUploadBuffer(path string, paramName string) (bytes.Buffer, string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, "", err
+		return bytes.Buffer{}, "", err
 	}
 	defer file.Close()
 
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
+	body := bytes.Buffer{}
+	writer := multipart.NewWriter(&body)
 	part, err := writer.CreateFormFile(paramName, filepath.Base(path))
 	if err != nil {
-		return nil, "", err
+		return bytes.Buffer{}, "", err
 	}
 	_, err = io.Copy(part, file)
 	if err != nil {
-		return nil, "", err
+		return bytes.Buffer{}, "", err
 	}
 
 	err = writer.Close()
 
-	return bytes.NewReader(body.Bytes()), writer.FormDataContentType(), err
+	return body, writer.FormDataContentType(), err
 }
 
-func (client *Client) uploadAsynchronously(request *cloudcontroller.Request, writeErrors <-chan error) (Package, Warnings, error) {
-	var pkg Package
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &pkg,
-	}
-
-	httpErrors := make(chan error)
-
-	go func() {
-		defer close(httpErrors)
-
-		err := client.connection.Make(request, &response)
-		if err != nil {
-			httpErrors <- err
-		}
-	}()
-
-	// The following section makes the following assumptions:
-	// 1) If an error occurs during file reading, an EOF is sent to the request
-	// object. Thus ending the request transfer.
-	// 2) If an error occurs during request transfer, an EOF is sent to the pipe.
-	// Thus ending the writing routine.
-	var firstError error
-	var writeClosed, httpClosed bool
-
-	for {
-		select {
-		case writeErr, ok := <-writeErrors:
-			if !ok {
-				writeClosed = true
-				break // for select
-			}
-			if firstError == nil {
-				firstError = writeErr
-			}
-		case httpErr, ok := <-httpErrors:
-			if !ok {
-				httpClosed = true
-				break // for select
-			}
-			if firstError == nil {
-				firstError = httpErr
-			}
-		}
-
-		if writeClosed && httpClosed {
-			break // for for
-		}
-	}
-
-	return pkg, response.Warnings, firstError
-}
-
-func (client *Client) uploadExistingResourcesOnly(uploadLink APILink, matchedResources []Resource) (Package, Warnings, error) {
+func (client *Client) uploadExistingResourcesOnly(packageGUID string, matchedResources []Resource) (resources.Package, Warnings, error) {
 	jsonResources, err := json.Marshal(matchedResources)
 	if err != nil {
-		return Package{}, nil, err
+		return resources.Package{}, nil, err
 	}
 
 	body := bytes.NewBuffer(nil)
 	form := multipart.NewWriter(body)
 	err = form.WriteField("resources", string(jsonResources))
 	if err != nil {
-		return Package{}, nil, err
+		return resources.Package{}, nil, err
 	}
 
 	err = form.Close()
 	if err != nil {
-		return Package{}, nil, err
+		return resources.Package{}, nil, err
 	}
 
-	request, err := client.newHTTPRequest(requestOptions{
-		URL:    uploadLink.HREF,
-		Method: uploadLink.Method,
-		Body:   bytes.NewReader(body.Bytes()),
-	})
-	if err != nil {
-		return Package{}, nil, err
-	}
+	responsePackage := resources.Package{}
 
-	request.Header.Set("Content-Type", form.FormDataContentType())
+	_, warnings, err := client.MakeRequestSendRaw(
+		internal.PostPackageBitsRequest,
+		internal.Params{"package_guid": packageGUID},
+		body.Bytes(),
+		form.FormDataContentType(),
+		&responsePackage,
+	)
 
-	var pkg Package
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &pkg,
-	}
-
-	err = client.connection.Make(request, &response)
-	return pkg, response.Warnings, err
+	return responsePackage, warnings, err
 }
 
-func (client *Client) uploadNewAndExistingResources(uploadLink APILink, matchedResources []Resource, newResources io.Reader, newResourcesLength int64) (Package, Warnings, error) {
+func (client *Client) uploadNewAndExistingResources(packageGUID string, matchedResources []Resource, newResources io.Reader, newResourcesLength int64) (resources.Package, Warnings, error) {
 	contentLength, err := client.calculateAppBitsRequestSize(matchedResources, newResourcesLength)
 	if err != nil {
-		return Package{}, nil, err
+		return resources.Package{}, nil, err
 	}
 
 	contentType, body, writeErrors := client.createMultipartBodyAndHeaderForAppBits(matchedResources, newResources, newResourcesLength)
 
-	// This request uses URL/Method instead of an internal RequestName to support
-	// the possibility of external bit services.
-	request, err := client.newHTTPRequest(requestOptions{
-		URL:    uploadLink.HREF,
-		Method: uploadLink.Method,
-		Body:   body,
-	})
-	if err != nil {
-		return Package{}, nil, err
-	}
-
-	request.Header.Set("Content-Type", contentType)
-	request.ContentLength = contentLength
-
-	return client.uploadAsynchronously(request, writeErrors)
+	responseBody := resources.Package{}
+	_, warnings, err := client.MakeRequestUploadAsync(
+		internal.PostPackageBitsRequest,
+		internal.Params{"package_guid": packageGUID},
+		contentType,
+		body,
+		contentLength,
+		&responseBody,
+		writeErrors,
+	)
+	return responseBody, warnings, err
 }

--- a/api/cloudcontroller/ccv3/process.go
+++ b/api/cloudcontroller/ccv3/process.go
@@ -1,236 +1,142 @@
 package ccv3
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller"
-	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/cli/resources"
 )
 
-type Process struct {
-	GUID string
-	Type string
-	// Command is the process start command. Note: This value will be obfuscated when obtained from listing.
-	Command                      types.FilteredString
-	HealthCheckType              constant.HealthCheckType
-	HealthCheckEndpoint          string
-	HealthCheckInvocationTimeout int64
-	HealthCheckTimeout           int64
-	Instances                    types.NullInt
-	MemoryInMB                   types.NullUint64
-	DiskInMB                     types.NullUint64
-}
-
-func (p Process) MarshalJSON() ([]byte, error) {
-	var ccProcess marshalProcess
-
-	marshalCommand(p, &ccProcess)
-	marshalInstances(p, &ccProcess)
-	marshalMemory(p, &ccProcess)
-	marshalDisk(p, &ccProcess)
-	marshalHealthCheck(p, &ccProcess)
-
-	return json.Marshal(ccProcess)
-}
-
-func (p *Process) UnmarshalJSON(data []byte) error {
-	var ccProcess struct {
-		Command    types.FilteredString `json:"command"`
-		DiskInMB   types.NullUint64     `json:"disk_in_mb"`
-		GUID       string               `json:"guid"`
-		Instances  types.NullInt        `json:"instances"`
-		MemoryInMB types.NullUint64     `json:"memory_in_mb"`
-		Type       string               `json:"type"`
-
-		HealthCheck struct {
-			Type constant.HealthCheckType `json:"type"`
-			Data struct {
-				Endpoint          string `json:"endpoint"`
-				InvocationTimeout int64  `json:"invocation_timeout"`
-				Timeout           int64  `json:"timeout"`
-			} `json:"data"`
-		} `json:"health_check"`
-	}
-
-	err := cloudcontroller.DecodeJSON(data, &ccProcess)
-	if err != nil {
-		return err
-	}
-
-	p.Command = ccProcess.Command
-	p.DiskInMB = ccProcess.DiskInMB
-	p.GUID = ccProcess.GUID
-	p.HealthCheckEndpoint = ccProcess.HealthCheck.Data.Endpoint
-	p.HealthCheckInvocationTimeout = ccProcess.HealthCheck.Data.InvocationTimeout
-	p.HealthCheckTimeout = ccProcess.HealthCheck.Data.Timeout
-	p.HealthCheckType = ccProcess.HealthCheck.Type
-	p.Instances = ccProcess.Instances
-	p.MemoryInMB = ccProcess.MemoryInMB
-	p.Type = ccProcess.Type
-
-	return nil
-}
-
 // CreateApplicationProcessScale updates process instances count, memory or disk
-func (client *Client) CreateApplicationProcessScale(appGUID string, process Process) (Process, Warnings, error) {
-	body, err := json.Marshal(process)
-	if err != nil {
-		return Process{}, nil, err
-	}
+func (client *Client) CreateApplicationProcessScale(appGUID string, process resources.Process) (resources.Process, Warnings, error) {
+	var responseBody resources.Process
 
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.PostApplicationProcessActionScaleRequest,
-		Body:        bytes.NewReader(body),
-		URIParams:   internal.Params{"app_guid": appGUID, "type": process.Type},
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostApplicationProcessActionScaleRequest,
+		URIParams:    internal.Params{"app_guid": appGUID, "type": process.Type},
+		RequestBody:  process,
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Process{}, nil, err
-	}
 
-	var responseProcess Process
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseProcess,
-	}
-	err = client.connection.Make(request, &response)
-	return responseProcess, response.Warnings, err
+	return responseBody, warnings, err
 }
 
 // GetApplicationProcessByType returns application process of specified type
-func (client *Client) GetApplicationProcessByType(appGUID string, processType string) (Process, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetApplicationProcessRequest,
-		URIParams: map[string]string{
-			"app_guid": appGUID,
-			"type":     processType,
-		},
-	})
-	if err != nil {
-		return Process{}, nil, err
-	}
-	var process Process
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &process,
-	}
+func (client *Client) GetApplicationProcessByType(appGUID string, processType string) (resources.Process, Warnings, error) {
+	var responseBody resources.Process
 
-	err = client.connection.Make(request, &response)
-	return process, response.Warnings, err
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetApplicationProcessRequest,
+		URIParams:    internal.Params{"app_guid": appGUID, "type": processType},
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
 }
 
 // GetApplicationProcesses lists processes for a given application. **Note**:
 // Due to security, the API obfuscates certain values such as `command`.
-func (client *Client) GetApplicationProcesses(appGUID string) ([]Process, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetApplicationProcessesRequest,
-		URIParams:   map[string]string{"app_guid": appGUID},
+func (client *Client) GetApplicationProcesses(appGUID string) ([]resources.Process, Warnings, error) {
+	var processes []resources.Process
+
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetApplicationProcessesRequest,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		ResponseBody: resources.Process{},
+		AppendToList: func(item interface{}) error {
+			processes = append(processes, item.(resources.Process))
+			return nil
+		},
 	})
+
+	return processes, warnings, err
+}
+
+// GetNewApplicationProcesses gets processes for an application in the middle of a deployment.
+// The app's processes will include a web process that will be removed when the deployment completes,
+// so exclude that soon-to-be-removed process from the result.
+func (client *Client) GetNewApplicationProcesses(appGUID string, deploymentGUID string) ([]resources.Process, Warnings, error) {
+	var allWarnings Warnings
+
+	deployment, warnings, err := client.GetDeployment(deploymentGUID)
+	allWarnings = append(allWarnings, warnings...)
 	if err != nil {
-		return nil, nil, err
+		return nil, allWarnings, err
 	}
 
-	var fullProcessesList []Process
-	warnings, err := client.paginate(request, Process{}, func(item interface{}) error {
-		if process, ok := item.(Process); ok {
-			fullProcessesList = append(fullProcessesList, process)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   Process{},
-				Unexpected: item,
-			}
+	allProcesses, warnings, err := client.GetApplicationProcesses(appGUID)
+	allWarnings = append(allWarnings, warnings...)
+	if err != nil {
+		return nil, allWarnings, err
+	}
+
+	var newWebProcessGUID string
+	for _, process := range deployment.NewProcesses {
+		if process.Type == constant.ProcessTypeWeb {
+			newWebProcessGUID = process.GUID
 		}
-		return nil
+	}
+
+	var processesList []resources.Process
+	for _, process := range allProcesses {
+		if process.Type == constant.ProcessTypeWeb {
+			if process.GUID == newWebProcessGUID {
+				processesList = append(processesList, process)
+			}
+		} else {
+			processesList = append(processesList, process)
+		}
+	}
+
+	return processesList, allWarnings, nil
+}
+
+// GetProcess returns a process with the given guid
+func (client *Client) GetProcess(processGUID string) (resources.Process, Warnings, error) {
+	var responseBody resources.Process
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetProcessRequest,
+		URIParams:    internal.Params{"process_guid": processGUID},
+		ResponseBody: &responseBody,
 	})
 
-	return fullProcessesList, warnings, err
+	return responseBody, warnings, err
+}
+
+func (client Client) GetProcesses(query ...Query) ([]resources.Process, Warnings, error) {
+	var processes []resources.Process
+
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetProcessesRequest,
+		Query:        query,
+		ResponseBody: resources.Process{},
+		AppendToList: func(item interface{}) error {
+			processes = append(processes, item.(resources.Process))
+			return nil
+		},
+	})
+
+	return processes, warnings, err
 }
 
 // UpdateProcess updates the process's command or health check settings. GUID
 // is always required; HealthCheckType is only required when updating health
 // check settings.
-func (client *Client) UpdateProcess(process Process) (Process, Warnings, error) {
-	body, err := json.Marshal(Process{
-		Command:                      process.Command,
-		HealthCheckType:              process.HealthCheckType,
-		HealthCheckEndpoint:          process.HealthCheckEndpoint,
-		HealthCheckTimeout:           process.HealthCheckTimeout,
-		HealthCheckInvocationTimeout: process.HealthCheckInvocationTimeout,
-	})
-	if err != nil {
-		return Process{}, nil, err
-	}
+func (client *Client) UpdateProcess(process resources.Process) (resources.Process, Warnings, error) {
+	var responseBody resources.Process
 
-	request, err := client.newHTTPRequest(requestOptions{
+	_, warnings, err := client.MakeRequest(RequestParams{
 		RequestName: internal.PatchProcessRequest,
-		Body:        bytes.NewReader(body),
 		URIParams:   internal.Params{"process_guid": process.GUID},
+		RequestBody: resources.Process{
+			Command:                      process.Command,
+			HealthCheckType:              process.HealthCheckType,
+			HealthCheckEndpoint:          process.HealthCheckEndpoint,
+			HealthCheckTimeout:           process.HealthCheckTimeout,
+			HealthCheckInvocationTimeout: process.HealthCheckInvocationTimeout,
+		},
+		ResponseBody: &responseBody,
 	})
-	if err != nil {
-		return Process{}, nil, err
-	}
 
-	var responseProcess Process
-	response := cloudcontroller.Response{
-		DecodeJSONResponseInto: &responseProcess,
-	}
-	err = client.connection.Make(request, &response)
-	return responseProcess, response.Warnings, err
-}
-
-type healthCheck struct {
-	Type constant.HealthCheckType `json:"type,omitempty"`
-	Data struct {
-		Endpoint          interface{} `json:"endpoint,omitempty"`
-		InvocationTimeout int64       `json:"invocation_timeout,omitempty"`
-		Timeout           int64       `json:"timeout,omitempty"`
-	} `json:"data"`
-}
-
-type marshalProcess struct {
-	Command    interface{} `json:"command,omitempty"`
-	Instances  json.Number `json:"instances,omitempty"`
-	MemoryInMB json.Number `json:"memory_in_mb,omitempty"`
-	DiskInMB   json.Number `json:"disk_in_mb,omitempty"`
-
-	HealthCheck *healthCheck `json:"health_check,omitempty"`
-}
-
-func marshalCommand(p Process, ccProcess *marshalProcess) {
-	if p.Command.IsSet {
-		ccProcess.Command = &p.Command
-	}
-}
-
-func marshalDisk(p Process, ccProcess *marshalProcess) {
-	if p.DiskInMB.IsSet {
-		ccProcess.DiskInMB = json.Number(fmt.Sprint(p.DiskInMB.Value))
-	}
-}
-
-func marshalHealthCheck(p Process, ccProcess *marshalProcess) {
-	if p.HealthCheckType != "" || p.HealthCheckEndpoint != "" || p.HealthCheckInvocationTimeout != 0 || p.HealthCheckTimeout != 0 {
-		ccProcess.HealthCheck = new(healthCheck)
-		ccProcess.HealthCheck.Type = p.HealthCheckType
-		ccProcess.HealthCheck.Data.InvocationTimeout = p.HealthCheckInvocationTimeout
-		ccProcess.HealthCheck.Data.Timeout = p.HealthCheckTimeout
-		if p.HealthCheckEndpoint != "" {
-			ccProcess.HealthCheck.Data.Endpoint = p.HealthCheckEndpoint
-		}
-	}
-}
-
-func marshalInstances(p Process, ccProcess *marshalProcess) {
-	if p.Instances.IsSet {
-		ccProcess.Instances = json.Number(fmt.Sprint(p.Instances.Value))
-	}
-}
-
-func marshalMemory(p Process, ccProcess *marshalProcess) {
-	if p.MemoryInMB.IsSet {
-		ccProcess.MemoryInMB = json.Number(fmt.Sprint(p.MemoryInMB.Value))
-	}
+	return responseBody, warnings, err
 }

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -31,6 +31,10 @@ const (
 	FieldsServiceBroker QueryKey = "fields[service_broker]"
 	// FieldsServiceOfferingServiceBroker is a query parameter to include specific fields from a service broker in a plan response
 	FieldsServiceOfferingServiceBroker QueryKey = "fields[service_offering.service_broker]"
+	// FieldsSpace is a query parameter to include specific fields from a space
+	FieldsSpace QueryKey = "fields[space]"
+	// FieldsSpaceOrganization is a query parameter to include specific fields from a organization
+	FieldsSpaceOrganization QueryKey = "fields[space.organization]"
 
 	// UnmappedFilter is a query parameter specifying unmapped routes
 	UnmappedFilter QueryKey = "unmapped"

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -29,6 +29,14 @@ const (
 	ServiceBrokerNamesFilter QueryKey = "service_broker_names"
 	// StatesFilter is a query parameter when getting a package's droplets by state
 	StatesFilter QueryKey = "states"
+	// HostsFilter is a query param for listing objects by hostname
+	HostsFilter QueryKey = "hosts"
+	// HostFilter is a query param for getting an object with the given host
+	HostFilter QueryKey = "host"
+	// PathFilter is a query param for getting an object with the given host
+	PathFilter QueryKey = "path"
+	// PortFilter is a query param for getting an object with the given port (TCP routes)
+	PortFilter QueryKey = "port"
 
 	// FieldsServiceBroker is a query parameter to include specific fields from a service broker in an offering response
 	FieldsServiceBroker QueryKey = "fields[service_broker]"

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -32,6 +32,8 @@ const (
 	// FieldsServiceOfferingServiceBroker is a query parameter to include specific fields from a service broker in a plan response
 	FieldsServiceOfferingServiceBroker QueryKey = "fields[service_offering.service_broker]"
 
+	// UnmappedFilter is a query parameter specifying unmapped routes
+	UnmappedFilter QueryKey = "unmapped"
 	// OrderBy is a query parameter to specify how to order objects.
 	OrderBy QueryKey = "order_by"
 	// PerPage is a query parameter for specifying the number of results per page.

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -27,6 +27,9 @@ const (
 	StackFilter QueryKey = "stacks"
 	// ServiceBrokerNamesFilter is a query parameter when getting plans or offerings according to the Service Brokers that it relates to
 	ServiceBrokerNamesFilter QueryKey = "service_broker_names"
+	// StatesFilter is a query parameter when getting a package's droplets by state
+	StatesFilter QueryKey = "states"
+
 	// FieldsServiceBroker is a query parameter to include specific fields from a service broker in an offering response
 	FieldsServiceBroker QueryKey = "fields[service_broker]"
 	// FieldsServiceOfferingServiceBroker is a query parameter to include specific fields from a service broker in a plan response

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -25,6 +25,8 @@ const (
 	SpaceGUIDFilter QueryKey = "space_guids"
 	// StackFilter is a query parameter for listing objects by stack name
 	StackFilter QueryKey = "stacks"
+	// ServiceBrokerGUIDsFilter is a query parameter for getting resources according to the service broker GUID
+	ServiceBrokerGUIDsFilter QueryKey = "service_broker_guids"
 	// ServiceBrokerNamesFilter is a query parameter when getting plans or offerings according to the Service Brokers that it relates to
 	ServiceBrokerNamesFilter QueryKey = "service_broker_names"
 	// StatesFilter is a query parameter when getting a package's droplets by state

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -52,6 +52,10 @@ const (
 
 	// Purge is a query parameter used on a Delete request to indicate that dependent resources should also be deleted
 	Purge = "purge"
+
+	// SourceGUID is the query parameter for getting an object. Currently it's used as a package GUID
+	// to retrieve a package to later copy it to an app (CopyPackage())
+	SourceGUID = "source_guid"
 )
 
 // Query is additional settings that can be passed to some requests that can

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -25,7 +25,10 @@ const (
 	SpaceGUIDFilter QueryKey = "space_guids"
 	// StackFilter is a query parameter for listing objects by stack name
 	StackFilter QueryKey = "stacks"
-
+	// ServiceBrokerNamesFilter is a query parameter when getting plans or offerings according to the Service Brokers that it relates to
+	ServiceBrokerNamesFilter QueryKey = "service_broker_names"
+	// FieldsServiceBroker is a query parameter to include specific fields from a service broker in an offering response
+	FieldsServiceBroker QueryKey = "fields[service_broker]"
 	// OrderBy is a query parameter to specify how to order objects.
 	OrderBy QueryKey = "order_by"
 	// PerPage is a query parameter for specifying the number of results per page.
@@ -38,6 +41,9 @@ const (
 	// PositionOrder is a query value for ordering by position. This value is
 	// used in conjunction with the OrderBy QueryKey.
 	PositionOrder = "position"
+
+	// Purge is a query parameter used on a Delete request to indicate that dependent resources should also be deleted
+	Purge = "purge"
 )
 
 // Query is additional settings that can be passed to some requests that can

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -29,10 +29,16 @@ const (
 	ServiceBrokerNamesFilter QueryKey = "service_broker_names"
 	// FieldsServiceBroker is a query parameter to include specific fields from a service broker in an offering response
 	FieldsServiceBroker QueryKey = "fields[service_broker]"
+	// FieldsServiceOfferingServiceBroker is a query parameter to include specific fields from a service broker in a plan response
+	FieldsServiceOfferingServiceBroker QueryKey = "fields[service_offering.service_broker]"
+
 	// OrderBy is a query parameter to specify how to order objects.
 	OrderBy QueryKey = "order_by"
 	// PerPage is a query parameter for specifying the number of results per page.
 	PerPage QueryKey = "per_page"
+	// Include is a query parameter for specifying other resources associated with the
+	// resource returned by the endpoint
+	Include QueryKey = "include"
 
 	// NameOrder is a query value for ordering by name. This value is used in
 	// conjunction with the OrderBy QueryKey.

--- a/api/cloudcontroller/ccv3/relationships.go
+++ b/api/cloudcontroller/ccv3/relationships.go
@@ -1,7 +1,0 @@
-package ccv3
-
-import "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
-
-// Relationships represent associations between resources. Relationships is a
-// map of RelationshipTypes to Relationship.
-type Relationships map[constant.RelationshipType]Relationship

--- a/api/cloudcontroller/ccv3/route.go
+++ b/api/cloudcontroller/ccv3/route.go
@@ -1,0 +1,127 @@
+package ccv3
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
+)
+
+func (client Client) CreateRoute(route resources.Route) (resources.Route, Warnings, error) {
+	var responseBody resources.Route
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostRouteRequest,
+		RequestBody:  route,
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}
+
+func (client Client) DeleteOrphanedRoutes(spaceGUID string) (JobURL, Warnings, error) {
+	jobURL, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.DeleteOrphanedRoutesRequest,
+		URIParams:   internal.Params{"space_guid": spaceGUID},
+		Query:       []Query{{Key: UnmappedFilter, Values: []string{"true"}}},
+	})
+
+	return jobURL, warnings, err
+}
+
+func (client Client) DeleteRoute(routeGUID string) (JobURL, Warnings, error) {
+	jobURL, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.DeleteRouteRequest,
+		URIParams:   internal.Params{"route_guid": routeGUID},
+	})
+
+	return jobURL, warnings, err
+}
+
+func (client Client) GetApplicationRoutes(appGUID string) ([]resources.Route, Warnings, error) {
+	var routes []resources.Route
+
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetApplicationRoutesRequest,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		ResponseBody: resources.Route{},
+		AppendToList: func(item interface{}) error {
+			routes = append(routes, item.(resources.Route))
+			return nil
+		},
+	})
+
+	return routes, warnings, err
+}
+
+func (client Client) GetRouteDestinations(routeGUID string) ([]resources.RouteDestination, Warnings, error) {
+	var responseBody struct {
+		Destinations []resources.RouteDestination `json:"destinations"`
+	}
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetRouteDestinationsRequest,
+		URIParams:    internal.Params{"route_guid": routeGUID},
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody.Destinations, warnings, err
+}
+
+func (client Client) GetRoutes(query ...Query) ([]resources.Route, Warnings, error) {
+	var routes []resources.Route
+
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetRoutesRequest,
+		Query:        query,
+		ResponseBody: resources.Route{},
+		AppendToList: func(item interface{}) error {
+			routes = append(routes, item.(resources.Route))
+			return nil
+		},
+	})
+
+	return routes, warnings, err
+}
+
+func (client Client) MapRoute(routeGUID string, appGUID string) (Warnings, error) {
+	type destinationProcess struct {
+		ProcessType string `json:"process_type"`
+	}
+
+	type destinationApp struct {
+		GUID    string              `json:"guid"`
+		Process *destinationProcess `json:"process,omitempty"`
+	}
+	type destination struct {
+		App destinationApp `json:"app"`
+	}
+
+	type body struct {
+		Destinations []destination `json:"destinations"`
+	}
+
+	requestBody := body{
+		Destinations: []destination{
+			{App: destinationApp{GUID: appGUID}},
+		},
+	}
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.MapRouteRequest,
+		URIParams:   internal.Params{"route_guid": routeGUID},
+		RequestBody: &requestBody,
+	})
+
+	return warnings, err
+}
+
+func (client Client) UnmapRoute(routeGUID string, destinationGUID string) (Warnings, error) {
+	var responseBody resources.Build
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.UnmapRouteRequest,
+		URIParams:    internal.Params{"route_guid": routeGUID, "destination_guid": destinationGUID},
+		ResponseBody: &responseBody,
+	})
+
+	return warnings, err
+}

--- a/api/cloudcontroller/ccv3/service_credential_binding.go
+++ b/api/cloudcontroller/ccv3/service_credential_binding.go
@@ -1,0 +1,72 @@
+package ccv3
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
+)
+
+func (client *Client) CreateServiceCredentialBinding(binding resources.ServiceCredentialBinding) (JobURL, Warnings, error) {
+	return client.MakeRequest(RequestParams{
+		RequestName: internal.PostServiceCredentialBindingRequest,
+		RequestBody: binding,
+	})
+}
+
+// CreateUserProvidedServiceCredentialBinding creates the binding for a user-provided service instance
+// Does not return joburl
+func (client *Client) CreateUserProvidedServiceCredentialBinding(binding resources.ServiceCredentialBinding) (resources.ServiceCredentialBinding, Warnings, error) {
+	var responseBody resources.ServiceCredentialBinding
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostServiceCredentialBindingRequest,
+		RequestBody:  binding,
+		ResponseBody: &responseBody,
+	})
+	return responseBody, warnings, err
+}
+
+// GetServiceCredentialBindings queries the CC API with the specified query
+// and returns a slice of ServiceCredentialBindings. Additionally if Apps are
+// included in the API response (by having `include=app` in the query) then the
+// App names will be added into each ServiceCredentialBinding for app bindings
+func (client *Client) GetServiceCredentialBindings(query ...Query) ([]resources.ServiceCredentialBinding, Warnings, error) {
+	var result []resources.ServiceCredentialBinding
+
+	included, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetServiceCredentialBindingsRequest,
+		Query:        query,
+		ResponseBody: resources.ServiceCredentialBinding{},
+		AppendToList: func(item interface{}) error {
+			result = append(result, item.(resources.ServiceCredentialBinding))
+			return nil
+		},
+	})
+
+	if len(included.Apps) > 0 {
+		appLookup := lookuptable.AppFromGUID(included.Apps)
+
+		for i := range result {
+			result[i].AppName = appLookup[result[i].AppGUID].Name
+			result[i].AppSpaceGUID = appLookup[result[i].AppGUID].SpaceGUID
+		}
+	}
+
+	return result, warnings, err
+}
+
+func (client *Client) DeleteServiceCredentialBinding(guid string) (JobURL, Warnings, error) {
+	return client.MakeRequest(RequestParams{
+		RequestName: internal.DeleteServiceCredentialBindingRequest,
+		URIParams:   internal.Params{"service_credential_binding_guid": guid},
+	})
+}
+
+func (client *Client) GetServiceCredentialBindingDetails(guid string) (details resources.ServiceCredentialBindingDetails, warnings Warnings, err error) {
+	_, warnings, err = client.MakeRequest(RequestParams{
+		RequestName:  internal.GetServiceCredentialBindingDetailsRequest,
+		URIParams:    internal.Params{"service_credential_binding_guid": guid},
+		ResponseBody: &details,
+	})
+
+	return
+}

--- a/api/cloudcontroller/ccv3/service_instance.go
+++ b/api/cloudcontroller/ccv3/service_instance.go
@@ -2,39 +2,183 @@ package ccv3
 
 import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
-// ServiceInstance represents a Cloud Controller V3 Service Instance.
-type ServiceInstance struct {
-	// GUID is a unique service instance identifier.
-	GUID string `json:"guid"`
-	// Name is the name of the service instance.
-	Name string `json:"name"`
+type SpaceWithOrganization struct {
+	SpaceGUID        string
+	SpaceName        string
+	OrganizationName string
 }
 
 // GetServiceInstances lists service instances with optional filters.
-func (client *Client) GetServiceInstances(query ...Query) ([]ServiceInstance, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetServiceInstancesRequest,
-		Query:       query,
+func (client *Client) GetServiceInstances(query ...Query) ([]resources.ServiceInstance, IncludedResources, Warnings, error) {
+	var result []resources.ServiceInstance
+
+	included, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetServiceInstancesRequest,
+		Query:        query,
+		ResponseBody: resources.ServiceInstance{},
+		AppendToList: func(item interface{}) error {
+			result = append(result, item.(resources.ServiceInstance))
+			return nil
+		},
 	})
+
+	return result, included, warnings, err
+}
+
+func (client *Client) GetServiceInstanceByNameAndSpace(name, spaceGUID string, query ...Query) (resources.ServiceInstance, IncludedResources, Warnings, error) {
+	query = append(query,
+		Query{
+			Key:    NameFilter,
+			Values: []string{name},
+		},
+		Query{
+			Key:    SpaceGUIDFilter,
+			Values: []string{spaceGUID},
+		},
+	)
+
+	instances, included, warnings, err := client.GetServiceInstances(query...)
+
 	if err != nil {
-		return nil, nil, err
+		return resources.ServiceInstance{}, IncludedResources{}, warnings, err
 	}
 
-	var fullServiceInstanceList []ServiceInstance
-	warnings, err := client.paginate(request, ServiceInstance{}, func(item interface{}) error {
-		if serviceInstance, ok := item.(ServiceInstance); ok {
-			fullServiceInstanceList = append(fullServiceInstanceList, serviceInstance)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   ServiceInstance{},
-				Unexpected: item,
+	if len(instances) == 0 {
+		return resources.ServiceInstance{},
+			IncludedResources{},
+			warnings,
+			ccerror.ServiceInstanceNotFoundError{
+				Name:      name,
+				SpaceGUID: spaceGUID,
 			}
-		}
-		return nil
+	}
+
+	return instances[0], included, warnings, nil
+}
+
+func (client *Client) GetServiceInstanceParameters(serviceInstanceGUID string) (parameters types.JSONObject, warnings Warnings, err error) {
+	_, warnings, err = client.MakeRequest(RequestParams{
+		RequestName:  internal.GetServiceInstanceParametersRequest,
+		URIParams:    internal.Params{"service_instance_guid": serviceInstanceGUID},
+		ResponseBody: &parameters,
 	})
 
-	return fullServiceInstanceList, warnings, err
+	return
+}
+
+// GetUserProvidedServiceInstanceCredentails get credentials for a user-provided service instance only
+// Does not return async job url
+func (client *Client) GetUserProvidedServiceInstanceCredentails(serviceInstanceGUID string) (types.JSONObject, Warnings, error) {
+	var creds types.JSONObject
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetServiceInstanceCredentialsRequest,
+		URIParams:    internal.Params{"service_instance_guid": serviceInstanceGUID},
+		ResponseBody: &creds,
+	})
+
+	return creds, warnings, err
+}
+
+func (client *Client) CreateServiceInstance(serviceInstance resources.ServiceInstance) (JobURL, Warnings, error) {
+	return client.MakeRequest(RequestParams{
+		RequestName: internal.PostServiceInstanceRequest,
+		RequestBody: serviceInstance,
+	})
+}
+
+// CreateUserProvidedServiceInstance return the service instance in response body because create requests for User-provided service instances don't return jobURLs
+func (client *Client) CreateUserProvidedServiceInstance(serviceInstance resources.ServiceInstance) (resources.ServiceInstance, Warnings, error) {
+	var responseBody resources.ServiceInstance
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PostServiceInstanceRequest,
+		RequestBody:  serviceInstance,
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}
+
+// UpdateUserProvidedServiceInstance return the service instance in response body instead of jobURLs
+func (client *Client) UpdateUserProvidedServiceInstance(serviceInstanceGUID string, serviceInstanceUpdates resources.ServiceInstance) (resources.ServiceInstance, Warnings, error) {
+	var responseBody resources.ServiceInstance
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PatchServiceInstanceRequest,
+		URIParams:    internal.Params{"service_instance_guid": serviceInstanceGUID},
+		RequestBody:  serviceInstanceUpdates,
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}
+
+func (client *Client) UpdateServiceInstance(serviceInstanceGUID string, serviceInstanceUpdates resources.ServiceInstance) (JobURL, Warnings, error) {
+	return client.MakeRequest(RequestParams{
+		RequestName: internal.PatchServiceInstanceRequest,
+		URIParams:   internal.Params{"service_instance_guid": serviceInstanceGUID},
+		RequestBody: serviceInstanceUpdates,
+	})
+}
+
+func (client *Client) DeleteServiceInstance(serviceInstanceGUID string, query ...Query) (JobURL, Warnings, error) {
+	return client.MakeRequest(RequestParams{
+		RequestName: internal.DeleteServiceInstanceRequest,
+		URIParams:   internal.Params{"service_instance_guid": serviceInstanceGUID},
+		Query:       query,
+	})
+}
+
+// GetServiceInstanceSharedSpaces will fetch relationships between
+// a service instance and the shared-to spaces for that service.
+func (client *Client) GetServiceInstanceSharedSpaces(serviceInstanceGUID string) ([]SpaceWithOrganization, Warnings, error) {
+	var responseBody resources.SharedToSpacesListWrapper
+	query := []Query{
+		{
+			Key:    FieldsSpace,
+			Values: []string{"guid", "name", "relationships.organization"},
+		},
+		{
+			Key:    FieldsSpaceOrganization,
+			Values: []string{"guid", "name"},
+		},
+	}
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetServiceInstanceRelationshipsSharedSpacesRequest,
+		URIParams:    internal.Params{"service_instance_guid": serviceInstanceGUID},
+		Query:        query,
+		ResponseBody: &responseBody,
+	})
+	return mapRelationshipsToSpaces(responseBody), warnings, err
+}
+
+func (client *Client) GetServiceInstanceUsageSummary(serviceInstanceGUID string) ([]resources.ServiceInstanceUsageSummary, Warnings, error) {
+	var result resources.ServiceInstanceUsageSummaryList
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.GetServiceInstanceSharedSpacesUsageSummaryRequest,
+		URIParams:    internal.Params{"service_instance_guid": serviceInstanceGUID},
+		ResponseBody: &result,
+	})
+	return result.UsageSummary, warnings, err
+}
+
+func mapRelationshipsToSpaces(sharedToSpaces resources.SharedToSpacesListWrapper) []SpaceWithOrganization {
+	var spacesToReturn []SpaceWithOrganization
+
+	guidToOrgNameLookup := lookuptable.NameFromGUID(sharedToSpaces.Organizations)
+
+	for _, s := range sharedToSpaces.Spaces {
+		org := s.Relationships[constant.RelationshipTypeOrganization]
+		space := SpaceWithOrganization{SpaceGUID: s.GUID, SpaceName: s.Name, OrganizationName: guidToOrgNameLookup[org.GUID]}
+		spacesToReturn = append(spacesToReturn, space)
+	}
+
+	return spacesToReturn
 }

--- a/api/cloudcontroller/ccv3/service_offering.go
+++ b/api/cloudcontroller/ccv3/service_offering.go
@@ -1,0 +1,78 @@
+package ccv3
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
+)
+
+// GetServiceOfferings lists service offering with optional filters.
+func (client *Client) GetServiceOfferings(query ...Query) ([]resources.ServiceOffering, Warnings, error) {
+	var result []resources.ServiceOffering
+
+	query = append(query, Query{Key: FieldsServiceBroker, Values: []string{"name", "guid"}})
+
+	included, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetServiceOfferingsRequest,
+		Query:        query,
+		ResponseBody: resources.ServiceOffering{},
+		AppendToList: func(item interface{}) error {
+			result = append(result, item.(resources.ServiceOffering))
+			return nil
+		},
+	})
+
+	brokerNameLookup := make(map[string]string)
+	for _, b := range included.ServiceBrokers {
+		brokerNameLookup[b.GUID] = b.Name
+	}
+
+	for i, _ := range result {
+		result[i].ServiceBrokerName = brokerNameLookup[result[i].ServiceBrokerGUID]
+	}
+
+	return result, warnings, err
+}
+
+func (client *Client) GetServiceOfferingByNameAndBroker(serviceOfferingName, serviceBrokerName string) (resources.ServiceOffering, Warnings, error) {
+	query := []Query{{Key: NameFilter, Values: []string{serviceOfferingName}}}
+	if serviceBrokerName != "" {
+		query = append(query, Query{Key: ServiceBrokerNamesFilter, Values: []string{serviceBrokerName}})
+	}
+
+	offerings, warnings, err := client.GetServiceOfferings(query...)
+	if err != nil {
+		return resources.ServiceOffering{}, warnings, err
+	}
+
+	switch len(offerings) {
+	case 0:
+		return resources.ServiceOffering{}, warnings, ccerror.ServiceOfferingNotFoundError{
+			ServiceOfferingName: serviceOfferingName,
+			ServiceBrokerName:   serviceBrokerName,
+		}
+	case 1:
+		return offerings[0], warnings, nil
+	default:
+		return resources.ServiceOffering{}, warnings, ccerror.ServiceOfferingNameAmbiguityError{
+			ServiceOfferingName: serviceOfferingName,
+			ServiceBrokerNames:  extractServiceBrokerNames(offerings),
+		}
+	}
+}
+
+func (client *Client) PurgeServiceOffering(serviceOfferingGUID string) (Warnings, error) {
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.DeleteServiceOfferingRequest,
+		URIParams:   internal.Params{"service_offering_guid": serviceOfferingGUID},
+		Query:       []Query{{Key: Purge, Values: []string{"true"}}},
+	})
+	return warnings, err
+}
+
+func extractServiceBrokerNames(offerings []resources.ServiceOffering) (result []string) {
+	for _, o := range offerings {
+		result = append(result, o.ServiceBrokerName)
+	}
+	return
+}

--- a/api/cloudcontroller/ccv3/service_plan.go
+++ b/api/cloudcontroller/ccv3/service_plan.go
@@ -1,0 +1,160 @@
+package ccv3
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
+)
+
+// GetServicePlans lists service plan with optional filters.
+func (client *Client) GetServicePlans(query ...Query) ([]resources.ServicePlan, Warnings, error) {
+	plans, _, warnings, err := client.getServicePlans(query...)
+	return plans, warnings, err
+}
+
+func (client *Client) getServicePlans(query ...Query) ([]resources.ServicePlan, IncludedResources, Warnings, error) {
+	var plans []resources.ServicePlan
+
+	included, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetServicePlansRequest,
+		Query:        query,
+		ResponseBody: resources.ServicePlan{},
+		AppendToList: func(item interface{}) error {
+			plans = append(plans, item.(resources.ServicePlan))
+			return nil
+		},
+	})
+
+	return plans, included, warnings, err
+}
+
+type ServicePlanWithSpaceAndOrganization struct {
+	// GUID is a unique service plan identifier.
+	GUID string
+	// Name is the name of the service plan.
+	Name string
+	// VisibilityType can be "public", "admin", "organization" or "space"
+	VisibilityType resources.ServicePlanVisibilityType
+	// ServicePlanGUID is the GUID of the service offering
+	ServiceOfferingGUID string
+
+	SpaceGUID string
+
+	SpaceName string
+
+	OrganizationName string
+}
+
+type planSpaceDetails struct{ spaceName, orgName string }
+
+func (client *Client) GetServicePlansWithSpaceAndOrganization(query ...Query) ([]ServicePlanWithSpaceAndOrganization, Warnings, error) {
+	query = append(query, Query{
+		Key:    Include,
+		Values: []string{"space.organization"},
+	})
+
+	plans, included, warnings, err := client.getServicePlans(query...)
+
+	spaceDetailsFromGUID := computeSpaceDetailsTable(included)
+
+	var enrichedPlans []ServicePlanWithSpaceAndOrganization
+	for _, plan := range plans {
+		sd := spaceDetailsFromGUID[plan.SpaceGUID]
+
+		enrichedPlans = append(enrichedPlans, ServicePlanWithSpaceAndOrganization{
+			GUID:                plan.GUID,
+			Name:                plan.Name,
+			VisibilityType:      plan.VisibilityType,
+			ServiceOfferingGUID: plan.ServiceOfferingGUID,
+			SpaceGUID:           plan.SpaceGUID,
+			SpaceName:           sd.spaceName,
+			OrganizationName:    sd.orgName,
+		})
+	}
+
+	return enrichedPlans, warnings, err
+}
+
+type ServiceOfferingWithPlans struct {
+	// GUID is a unique service offering identifier.
+	GUID string
+	// Name is the name of the service offering.
+	Name string
+	// Description of the service offering
+	Description string
+	// ServiceBrokerName is the name of the service broker
+	ServiceBrokerName string
+
+	// List of service plans that this service offering provides
+	Plans []resources.ServicePlan
+}
+
+func (client *Client) GetServicePlansWithOfferings(query ...Query) ([]ServiceOfferingWithPlans, Warnings, error) {
+	query = append(query, Query{
+		Key:    Include,
+		Values: []string{"service_offering"},
+	})
+	query = append(query, Query{
+		Key:    FieldsServiceOfferingServiceBroker,
+		Values: []string{"name,guid"},
+	})
+
+	plans, included, warnings, err := client.getServicePlans(query...)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var offeringsWithPlans []ServiceOfferingWithPlans
+	offeringGUIDLookup := make(map[string]int)
+
+	indexOfOffering := func(serviceOfferingGUID string) int {
+		if i, ok := offeringGUIDLookup[serviceOfferingGUID]; ok {
+			return i
+		}
+
+		i := len(offeringsWithPlans)
+		offeringGUIDLookup[serviceOfferingGUID] = i
+		offeringsWithPlans = append(offeringsWithPlans, ServiceOfferingWithPlans{GUID: serviceOfferingGUID})
+
+		return i
+	}
+
+	brokerNameLookup := make(map[string]string)
+	for _, b := range included.ServiceBrokers {
+		brokerNameLookup[b.GUID] = b.Name
+	}
+
+	for _, p := range plans {
+		i := indexOfOffering(p.ServiceOfferingGUID)
+		offeringsWithPlans[i].Plans = append(offeringsWithPlans[i].Plans, p)
+	}
+
+	for _, o := range included.ServiceOfferings {
+		i := indexOfOffering(o.GUID)
+		offeringsWithPlans[i].Name = o.Name
+		offeringsWithPlans[i].Description = o.Description
+		offeringsWithPlans[i].ServiceBrokerName = brokerNameLookup[o.ServiceBrokerGUID]
+	}
+
+	return offeringsWithPlans, warnings, nil
+}
+
+func computeSpaceDetailsTable(included IncludedResources) map[string]planSpaceDetails {
+	orgNameFromGUID := make(map[string]string)
+	for _, org := range included.Organizations {
+		orgNameFromGUID[org.GUID] = org.Name
+	}
+
+	spaceDetailsFromGUID := make(map[string]planSpaceDetails)
+	for _, space := range included.Spaces {
+		details := planSpaceDetails{spaceName: space.Name}
+
+		if orgRelationship, ok := space.Relationships[constant.RelationshipTypeOrganization]; ok {
+			details.orgName = orgNameFromGUID[orgRelationship.GUID]
+		}
+
+		spaceDetailsFromGUID[space.GUID] = details
+	}
+
+	return spaceDetailsFromGUID
+}

--- a/api/cloudcontroller/ccv3/stack.go
+++ b/api/cloudcontroller/ccv3/stack.go
@@ -1,41 +1,23 @@
 package ccv3
 
 import (
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
 )
 
-type Stack struct {
-	// GUID is a unique stack identifier.
-	GUID string `json:"guid"`
-	// Name is the name of the stack.
-	Name string `json:"name"`
-	// Description is the description for the stack
-	Description string `json:"description"`
-}
-
 // GetStacks lists stacks with optional filters.
-func (client *Client) GetStacks(query ...Query) ([]Stack, Warnings, error) {
-	request, err := client.newHTTPRequest(requestOptions{
-		RequestName: internal.GetStacksRequest,
-		Query:       query,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
+func (client *Client) GetStacks(query ...Query) ([]resources.Stack, Warnings, error) {
+	var stacks []resources.Stack
 
-	var fullStacksList []Stack
-	warnings, err := client.paginate(request, Stack{}, func(item interface{}) error {
-		if stack, ok := item.(Stack); ok {
-			fullStacksList = append(fullStacksList, stack)
-		} else {
-			return ccerror.UnknownObjectInListError{
-				Expected:   Stack{},
-				Unexpected: item,
-			}
-		}
-		return nil
+	_, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetStacksRequest,
+		Query:        query,
+		ResponseBody: resources.Stack{},
+		AppendToList: func(item interface{}) error {
+			stacks = append(stacks, item.(resources.Stack))
+			return nil
+		},
 	})
 
-	return fullStacksList, warnings, err
+	return stacks, warnings, err
 }

--- a/api/cloudcontroller/ccv3/stack_test.go
+++ b/api/cloudcontroller/ccv3/stack_test.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	. "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	"code.cloudfoundry.org/cli/resources"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/ghttp"
@@ -22,7 +23,7 @@ var _ = Describe("Stacks", func() {
 		var (
 			query Query
 
-			stacks     []Stack
+			stacks     []resources.Stack
 			warnings   Warnings
 			executeErr error
 		)
@@ -88,9 +89,9 @@ var _ = Describe("Stacks", func() {
 				Expect(executeErr).NotTo(HaveOccurred())
 
 				Expect(stacks).To(ConsistOf(
-					Stack{Name: "stack-name-1", GUID: "stack-guid-1", Description: "stack desc 1"},
-					Stack{Name: "stack-name-2", GUID: "stack-guid-2", Description: "stack desc 2"},
-					Stack{Name: "stack-name-3", GUID: "stack-guid-3", Description: "stack desc 3"},
+					resources.Stack{Name: "stack-name-1", GUID: "stack-guid-1", Description: "stack desc 1"},
+					resources.Stack{Name: "stack-name-2", GUID: "stack-guid-2", Description: "stack desc 2"},
+					resources.Stack{Name: "stack-name-3", GUID: "stack-guid-3", Description: "stack desc 3"},
 				))
 				Expect(warnings).To(ConsistOf("this is a warning", "this is another warning"))
 			})

--- a/api/cloudcontroller/uploads/upload.go
+++ b/api/cloudcontroller/uploads/upload.go
@@ -1,0 +1,62 @@
+package uploads
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"path/filepath"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+)
+
+func CalculateRequestSize(fileSize int64, path string, fieldName string) (int64, error) {
+	body := &bytes.Buffer{}
+	form := multipart.NewWriter(body)
+
+	bpFileName := filepath.Base(path)
+
+	_, err := form.CreateFormFile(fieldName, bpFileName)
+	if err != nil {
+		return 0, err
+	}
+
+	err = form.Close()
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(body.Len()) + fileSize, nil
+}
+
+func CreateMultipartBodyAndHeader(file io.Reader, path string, fieldName string) (string, io.ReadSeeker, <-chan error) {
+	writerOutput, writerInput := cloudcontroller.NewPipeBomb()
+
+	form := multipart.NewWriter(writerInput)
+
+	writeErrors := make(chan error)
+
+	go func() {
+		defer close(writeErrors)
+		defer writerInput.Close()
+
+		bpFileName := filepath.Base(path)
+		writer, err := form.CreateFormFile(fieldName, bpFileName)
+		if err != nil {
+			writeErrors <- err
+			return
+		}
+
+		_, err = io.Copy(writer, file)
+		if err != nil {
+			writeErrors <- err
+			return
+		}
+
+		err = form.Close()
+		if err != nil {
+			writeErrors <- err
+		}
+	}()
+
+	return form.FormDataContentType(), writerOutput, writeErrors
+}

--- a/resources/api_links_resource.go
+++ b/resources/api_links_resource.go
@@ -1,0 +1,25 @@
+package resources
+
+// APILink represents a generic link from a response object.
+type APILink struct {
+	// HREF is the fully qualified URL for the link.
+	HREF string `json:"href"`
+	// Method indicate the desired action to be performed on the identified
+	// resource.
+	Method string `json:"method"`
+
+	// Meta contains additional metadata about the API.
+	Meta struct {
+		// Version of the API
+		Version string `json:"version"`
+
+		// Fingerprint to authenticate api with
+		HostKeyFingerprint string `json:"host_key_fingerprint"`
+
+		// Identifier for UAA queries
+		OAuthClient string `json:"oath_client"`
+	} `json:"meta"`
+}
+
+// APILinks is a directory of follow-up urls for the resource.
+type APILinks map[string]APILink

--- a/resources/application_feature_resource.go
+++ b/resources/application_feature_resource.go
@@ -1,0 +1,8 @@
+package resources
+
+type ApplicationFeature struct {
+	// Name of the application feature
+	Name    string
+	Enabled bool
+	//Reason  string `json:omitempty`
+}

--- a/resources/build_resource.go
+++ b/resources/build_resource.go
@@ -1,0 +1,69 @@
+package resources
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
+)
+
+// Build represent the process of staging an application package.
+type Build struct {
+	// CreatedAt is the time with zone when the build was created.
+	CreatedAt string
+	// DropletGUID is the unique identifier for the resulting droplet from the
+	// staging process.
+	DropletGUID string
+	// Error describes errors during the build process.
+	Error string
+	// GUID is the unique build identifier.
+	GUID string
+	// PackageGUID is the unique identifier for package that is the input to the
+	// staging process.
+	PackageGUID string
+	// State is the state of the build.
+	State constant.BuildState
+}
+
+// MarshalJSON converts a Build into a Cloud Controller Application.
+func (b Build) MarshalJSON() ([]byte, error) {
+	var ccBuild struct {
+		Package struct {
+			GUID string `json:"guid"`
+		} `json:"package"`
+	}
+
+	ccBuild.Package.GUID = b.PackageGUID
+
+	return json.Marshal(ccBuild)
+}
+
+// UnmarshalJSON helps unmarshal a Cloud Controller Build response.
+func (b *Build) UnmarshalJSON(data []byte) error {
+	var ccBuild struct {
+		CreatedAt string `json:"created_at,omitempty"`
+		GUID      string `json:"guid,omitempty"`
+		Error     string `json:"error"`
+		Package   struct {
+			GUID string `json:"guid"`
+		} `json:"package"`
+		State   constant.BuildState `json:"state,omitempty"`
+		Droplet struct {
+			GUID string `json:"guid"`
+		} `json:"droplet"`
+	}
+
+	err := cloudcontroller.DecodeJSON(data, &ccBuild)
+	if err != nil {
+		return err
+	}
+
+	b.GUID = ccBuild.GUID
+	b.CreatedAt = ccBuild.CreatedAt
+	b.Error = ccBuild.Error
+	b.PackageGUID = ccBuild.Package.GUID
+	b.State = ccBuild.State
+	b.DropletGUID = ccBuild.Droplet.GUID
+
+	return nil
+}

--- a/resources/deployment_resource.go
+++ b/resources/deployment_resource.go
@@ -1,0 +1,80 @@
+package resources
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
+)
+
+type Deployment struct {
+	GUID          string
+	State         constant.DeploymentState
+	StatusValue   constant.DeploymentStatusValue
+	StatusReason  constant.DeploymentStatusReason
+	RevisionGUID  string
+	DropletGUID   string
+	CreatedAt     string
+	UpdatedAt     string
+	Relationships Relationships
+	NewProcesses  []Process
+}
+
+// MarshalJSON converts a Deployment into a Cloud Controller Deployment.
+func (d Deployment) MarshalJSON() ([]byte, error) {
+	type Revision struct {
+		GUID string `json:"guid,omitempty"`
+	}
+	type Droplet struct {
+		GUID string `json:"guid,omitempty"`
+	}
+
+	var ccDeployment struct {
+		Droplet       *Droplet      `json:"droplet,omitempty"`
+		Revision      *Revision     `json:"revision,omitempty"`
+		Relationships Relationships `json:"relationships,omitempty"`
+	}
+
+	if d.DropletGUID != "" {
+		ccDeployment.Droplet = &Droplet{d.DropletGUID}
+	}
+
+	if d.RevisionGUID != "" {
+		ccDeployment.Revision = &Revision{d.RevisionGUID}
+	}
+
+	ccDeployment.Relationships = d.Relationships
+
+	return json.Marshal(ccDeployment)
+}
+
+// UnmarshalJSON helps unmarshal a Cloud Controller Deployment response.
+func (d *Deployment) UnmarshalJSON(data []byte) error {
+	var ccDeployment struct {
+		GUID          string                   `json:"guid,omitempty"`
+		CreatedAt     string                   `json:"created_at,omitempty"`
+		Relationships Relationships            `json:"relationships,omitempty"`
+		State         constant.DeploymentState `json:"state,omitempty"`
+		Status        struct {
+			Value  constant.DeploymentStatusValue  `json:"value"`
+			Reason constant.DeploymentStatusReason `json:"reason"`
+		} `json:"status"`
+		Droplet      Droplet   `json:"droplet,omitempty"`
+		NewProcesses []Process `json:"new_processes,omitempty"`
+	}
+	err := cloudcontroller.DecodeJSON(data, &ccDeployment)
+	if err != nil {
+		return err
+	}
+
+	d.GUID = ccDeployment.GUID
+	d.CreatedAt = ccDeployment.CreatedAt
+	d.Relationships = ccDeployment.Relationships
+	d.State = ccDeployment.State
+	d.StatusValue = ccDeployment.Status.Value
+	d.StatusReason = ccDeployment.Status.Reason
+	d.DropletGUID = ccDeployment.Droplet.GUID
+	d.NewProcesses = ccDeployment.NewProcesses
+
+	return nil
+}

--- a/resources/droplet_resource.go
+++ b/resources/droplet_resource.go
@@ -1,0 +1,37 @@
+package resources
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
+)
+
+// Droplet represents a Cloud Controller droplet's metadata. A droplet is a set of
+// compiled bits for a given application.
+type Droplet struct {
+	//Buildpacks are the detected buildpacks from the staging process.
+	Buildpacks []DropletBuildpack `json:"buildpacks,omitempty"`
+	// CreatedAt is the timestamp that the Cloud Controller created the droplet.
+	CreatedAt string `json:"created_at"`
+	// GUID is the unique droplet identifier.
+	GUID string `json:"guid"`
+	// Image is the Docker image name.
+	Image string `json:"image"`
+	// Stack is the root filesystem to use with the buildpack.
+	Stack string `json:"stack,omitempty"`
+	// State is the current state of the droplet.
+	State constant.DropletState `json:"state"`
+	// IsCurrent does not exist on the API layer, only on the actor layer; we ignore it w.r.t. JSON
+	IsCurrent bool `json:"-"`
+}
+
+// DropletBuildpack is the name and output of a buildpack used to create a
+// droplet.
+type DropletBuildpack struct {
+	// Name is the buildpack name.
+	Name string `json:"name"`
+	// BuildpackName is the the name reported by the buildpack.
+	BuildpackName string `json:"buildpack_name"`
+	// DetectOutput is the output of the buildpack detect script.
+	DetectOutput string `json:"detect_output"`
+	// Version is the version of the detected buildpack.
+	Version string `json:"version"`
+}

--- a/resources/environment_variables_resource.go
+++ b/resources/environment_variables_resource.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/types"
+)
+
+type EnvironmentVariables map[string]types.FilteredString
+
+func (variables EnvironmentVariables) MarshalJSON() ([]byte, error) {
+	ccEnvVars := struct {
+		Var map[string]types.FilteredString `json:"var"`
+	}{
+		Var: variables,
+	}
+
+	return json.Marshal(ccEnvVars)
+}
+
+func (variables *EnvironmentVariables) UnmarshalJSON(data []byte) error {
+	var ccEnvVars struct {
+		Var map[string]types.FilteredInterface `json:"var"`
+	}
+
+	err := cloudcontroller.DecodeJSON(data, &ccEnvVars)
+
+	*variables = EnvironmentVariables{}
+
+	for envVarName, envVarValue := range ccEnvVars.Var {
+		var valueAsString string
+		if str, ok := envVarValue.Value.(string); ok {
+			valueAsString = str
+		} else {
+			bytes, err := json.Marshal(envVarValue.Value)
+			if err != nil {
+				return err
+			}
+			valueAsString = string(bytes)
+		}
+
+		(*variables)[envVarName] = types.FilteredString{Value: valueAsString, IsSet: true}
+	}
+
+	return err
+}

--- a/resources/isolation_segment_resource.go
+++ b/resources/isolation_segment_resource.go
@@ -1,0 +1,9 @@
+package resources
+
+// IsolationSegment represents a Cloud Controller Isolation Segment.
+type IsolationSegment struct {
+	//GUID is the unique ID of the isolation segment.
+	GUID string `json:"guid,omitempty"`
+	//Name is the name of the isolation segment.
+	Name string `json:"name"`
+}

--- a/resources/package_resource.go
+++ b/resources/package_resource.go
@@ -1,0 +1,105 @@
+package resources
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
+)
+
+// Package represents a Cloud Controller V3 Package.
+type Package struct {
+	// CreatedAt is the time with zone when the object was created.
+	CreatedAt string
+
+	// DockerImage is the registry address of the docker image.
+	DockerImage string
+
+	// DockerPassword is the password for the docker image's registry.
+	DockerPassword string
+
+	// DockerUsername is the username for the docker image's registry.
+	DockerUsername string
+
+	// GUID is the unique identifier of the package.
+	GUID string
+
+	// Links are links to related resources.
+	Links APILinks
+
+	// Relationships are a list of relationships to other resources.
+	Relationships Relationships
+
+	// State is the state of the package.
+	State constant.PackageState
+
+	// Type is the package type.
+	Type constant.PackageType
+}
+
+// MarshalJSON converts a Package into a Cloud Controller Package.
+func (p Package) MarshalJSON() ([]byte, error) {
+	type ccPackageData struct {
+		Image    string `json:"image,omitempty"`
+		Username string `json:"username,omitempty"`
+		Password string `json:"password,omitempty"`
+	}
+	var ccPackage struct {
+		GUID          string                `json:"guid,omitempty"`
+		CreatedAt     string                `json:"created_at,omitempty"`
+		Links         APILinks              `json:"links,omitempty"`
+		Relationships Relationships         `json:"relationships,omitempty"`
+		State         constant.PackageState `json:"state,omitempty"`
+		Type          constant.PackageType  `json:"type,omitempty"`
+		Data          *ccPackageData        `json:"data,omitempty"`
+	}
+
+	ccPackage.GUID = p.GUID
+	ccPackage.CreatedAt = p.CreatedAt
+	ccPackage.Links = p.Links
+	ccPackage.Relationships = p.Relationships
+	ccPackage.State = p.State
+	ccPackage.Type = p.Type
+	if p.DockerImage != "" {
+		ccPackage.Data = &ccPackageData{
+			Image:    p.DockerImage,
+			Username: p.DockerUsername,
+			Password: p.DockerPassword,
+		}
+	}
+
+	return json.Marshal(ccPackage)
+}
+
+// UnmarshalJSON helps unmarshal a Cloud Controller Package response.
+func (p *Package) UnmarshalJSON(data []byte) error {
+	var ccPackage struct {
+		GUID          string                `json:"guid,omitempty"`
+		CreatedAt     string                `json:"created_at,omitempty"`
+		Links         APILinks              `json:"links,omitempty"`
+		Relationships Relationships         `json:"relationships,omitempty"`
+		State         constant.PackageState `json:"state,omitempty"`
+		Type          constant.PackageType  `json:"type,omitempty"`
+		Data          struct {
+			Image    string `json:"image"`
+			Username string `json:"username"`
+			Password string `json:"password"`
+		} `json:"data"`
+	}
+	err := cloudcontroller.DecodeJSON(data, &ccPackage)
+	if err != nil {
+		return err
+	}
+
+	p.GUID = ccPackage.GUID
+	p.CreatedAt = ccPackage.CreatedAt
+	p.Links = ccPackage.Links
+	p.Relationships = ccPackage.Relationships
+	p.State = ccPackage.State
+	p.Type = ccPackage.Type
+	p.DockerImage = ccPackage.Data.Image
+	p.DockerUsername = ccPackage.Data.Username
+	p.DockerPassword = ccPackage.Data.Password
+
+	return nil
+}

--- a/resources/process_resource.go
+++ b/resources/process_resource.go
@@ -1,0 +1,131 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
+	"code.cloudfoundry.org/cli/types"
+)
+
+type Process struct {
+	GUID string
+	Type string
+	// Command is the process start command. Note: This value will be obfuscated when obtained from listing.
+	Command                      types.FilteredString
+	HealthCheckType              constant.HealthCheckType
+	HealthCheckEndpoint          string
+	HealthCheckInvocationTimeout int64
+	HealthCheckTimeout           int64
+	Instances                    types.NullInt
+	MemoryInMB                   types.NullUint64
+	DiskInMB                     types.NullUint64
+	AppGUID                      string
+}
+
+func (p Process) MarshalJSON() ([]byte, error) {
+	var ccProcess marshalProcess
+
+	marshalCommand(p, &ccProcess)
+	marshalInstances(p, &ccProcess)
+	marshalMemory(p, &ccProcess)
+	marshalDisk(p, &ccProcess)
+	marshalHealthCheck(p, &ccProcess)
+
+	return json.Marshal(ccProcess)
+}
+
+func (p *Process) UnmarshalJSON(data []byte) error {
+	var ccProcess struct {
+		Command       types.FilteredString `json:"command"`
+		DiskInMB      types.NullUint64     `json:"disk_in_mb"`
+		GUID          string               `json:"guid"`
+		Instances     types.NullInt        `json:"instances"`
+		MemoryInMB    types.NullUint64     `json:"memory_in_mb"`
+		Type          string               `json:"type"`
+		Relationships Relationships        `json:"relationships"`
+
+		HealthCheck struct {
+			Type constant.HealthCheckType `json:"type"`
+			Data struct {
+				Endpoint          string `json:"endpoint"`
+				InvocationTimeout int64  `json:"invocation_timeout"`
+				Timeout           int64  `json:"timeout"`
+			} `json:"data"`
+		} `json:"health_check"`
+	}
+
+	err := cloudcontroller.DecodeJSON(data, &ccProcess)
+	if err != nil {
+		return err
+	}
+
+	p.Command = ccProcess.Command
+	p.DiskInMB = ccProcess.DiskInMB
+	p.GUID = ccProcess.GUID
+	p.HealthCheckEndpoint = ccProcess.HealthCheck.Data.Endpoint
+	p.HealthCheckInvocationTimeout = ccProcess.HealthCheck.Data.InvocationTimeout
+	p.HealthCheckTimeout = ccProcess.HealthCheck.Data.Timeout
+	p.HealthCheckType = ccProcess.HealthCheck.Type
+	p.Instances = ccProcess.Instances
+	p.MemoryInMB = ccProcess.MemoryInMB
+	p.Type = ccProcess.Type
+	p.AppGUID = ccProcess.Relationships[constant.RelationshipTypeApplication].GUID
+
+	return nil
+}
+
+type healthCheck struct {
+	Type constant.HealthCheckType `json:"type,omitempty"`
+	Data struct {
+		Endpoint          interface{} `json:"endpoint,omitempty"`
+		InvocationTimeout int64       `json:"invocation_timeout,omitempty"`
+		Timeout           int64       `json:"timeout,omitempty"`
+	} `json:"data"`
+}
+
+type marshalProcess struct {
+	Command    interface{} `json:"command,omitempty"`
+	Instances  json.Number `json:"instances,omitempty"`
+	MemoryInMB json.Number `json:"memory_in_mb,omitempty"`
+	DiskInMB   json.Number `json:"disk_in_mb,omitempty"`
+
+	HealthCheck *healthCheck `json:"health_check,omitempty"`
+}
+
+func marshalCommand(p Process, ccProcess *marshalProcess) {
+	if p.Command.IsSet {
+		ccProcess.Command = &p.Command
+	}
+}
+
+func marshalDisk(p Process, ccProcess *marshalProcess) {
+	if p.DiskInMB.IsSet {
+		ccProcess.DiskInMB = json.Number(fmt.Sprint(p.DiskInMB.Value))
+	}
+}
+
+func marshalHealthCheck(p Process, ccProcess *marshalProcess) {
+	if p.HealthCheckType != "" || p.HealthCheckEndpoint != "" || p.HealthCheckInvocationTimeout != 0 || p.HealthCheckTimeout != 0 {
+		ccProcess.HealthCheck = new(healthCheck)
+		ccProcess.HealthCheck.Type = p.HealthCheckType
+		ccProcess.HealthCheck.Data.InvocationTimeout = p.HealthCheckInvocationTimeout
+		ccProcess.HealthCheck.Data.Timeout = p.HealthCheckTimeout
+		if p.HealthCheckEndpoint != "" {
+			ccProcess.HealthCheck.Data.Endpoint = p.HealthCheckEndpoint
+		}
+	}
+}
+
+func marshalInstances(p Process, ccProcess *marshalProcess) {
+	if p.Instances.IsSet {
+		ccProcess.Instances = json.Number(fmt.Sprint(p.Instances.Value))
+	}
+}
+
+func marshalMemory(p Process, ccProcess *marshalProcess) {
+	if p.MemoryInMB.IsSet {
+		ccProcess.MemoryInMB = json.Number(fmt.Sprint(p.MemoryInMB.Value))
+	}
+}

--- a/resources/route_resource.go
+++ b/resources/route_resource.go
@@ -1,0 +1,118 @@
+package resources
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+)
+
+type RouteDestinationApp struct {
+	GUID    string
+	Process struct {
+		Type string
+	}
+}
+
+type RouteDestination struct {
+	GUID string
+	App  RouteDestinationApp
+}
+
+type Route struct {
+	GUID         string
+	SpaceGUID    string
+	DomainGUID   string
+	Host         string
+	Path         string
+	Protocol     string
+	Port         int
+	URL          string
+	Destinations []RouteDestination
+	Metadata     *Metadata
+}
+
+func (r Route) MarshalJSON() ([]byte, error) {
+	type Data struct {
+		GUID string `json:"guid,omitempty"`
+	}
+
+	type RelationshipData struct {
+		Data Data `json:"data,omitempty"`
+	}
+
+	type Relationships struct {
+		Space  RelationshipData `json:"space,omitempty"`
+		Domain RelationshipData `json:"domain,omitempty"`
+	}
+
+	// Building up the request body in ccRoute
+	type ccRoute struct {
+		GUID          string         `json:"guid,omitempty"`
+		Host          string         `json:"host,omitempty"`
+		Path          string         `json:"path,omitempty"`
+		Protocol      string         `json:"protocol,omitempty"`
+		Port          int            `json:"port,omitempty"`
+		Relationships *Relationships `json:"relationships,omitempty"`
+	}
+
+	ccR := ccRoute{
+		GUID:     r.GUID,
+		Host:     r.Host,
+		Path:     r.Path,
+		Protocol: r.Protocol,
+		Port:     r.Port,
+	}
+
+	if r.SpaceGUID != "" {
+		ccR.Relationships = &Relationships{
+			Space:  RelationshipData{Data{GUID: r.SpaceGUID}},
+			Domain: RelationshipData{Data{GUID: r.DomainGUID}},
+		}
+	}
+
+	return json.Marshal(ccR)
+}
+
+func (r *Route) UnmarshalJSON(data []byte) error {
+	var alias struct {
+		GUID         string             `json:"guid,omitempty"`
+		Protocol     string             `json:"protocol,omitempty"`
+		Host         string             `json:"host,omitempty"`
+		Path         string             `json:"path,omitempty"`
+		Port         int                `json:"port,omitempty"`
+		URL          string             `json:"url,omitempty"`
+		Destinations []RouteDestination `json:"destinations,omitempty"`
+		Metadata     *Metadata          `json:"metadata,omitempty"`
+
+		Relationships struct {
+			Space struct {
+				Data struct {
+					GUID string `json:"guid,omitempty"`
+				} `json:"data,omitempty"`
+			} `json:"space,omitempty"`
+			Domain struct {
+				Data struct {
+					GUID string `json:"guid,omitempty"`
+				} `json:"data,omitempty"`
+			} `json:"domain,omitempty"`
+		} `json:"relationships,omitempty"`
+	}
+
+	err := cloudcontroller.DecodeJSON(data, &alias)
+	if err != nil {
+		return err
+	}
+
+	r.GUID = alias.GUID
+	r.Protocol = alias.Protocol
+	r.Host = alias.Host
+	r.SpaceGUID = alias.Relationships.Space.Data.GUID
+	r.DomainGUID = alias.Relationships.Domain.Data.GUID
+	r.Path = alias.Path
+	r.Port = alias.Port
+	r.URL = alias.URL
+	r.Destinations = alias.Destinations
+	r.Metadata = alias.Metadata
+
+	return nil
+}

--- a/resources/service_credential_binding_details_resource.go
+++ b/resources/service_credential_binding_details_resource.go
@@ -1,0 +1,5 @@
+package resources
+
+type ServiceCredentialBindingDetails struct {
+	Credentials map[string]interface{} `json:"credentials"`
+}

--- a/resources/service_credential_binding_resource.go
+++ b/resources/service_credential_binding_resource.go
@@ -1,0 +1,43 @@
+package resources
+
+import (
+	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/jsonry"
+)
+
+type ServiceCredentialBindingType string
+
+const (
+	AppBinding ServiceCredentialBindingType = "app"
+	KeyBinding ServiceCredentialBindingType = "key"
+)
+
+type ServiceCredentialBinding struct {
+	// Type is either "app" or "key"
+	Type ServiceCredentialBindingType `jsonry:"type,omitempty"`
+	// GUID is a unique service credential binding identifier.
+	GUID string `jsonry:"guid,omitempty"`
+	// Name is the name of the service credential binding.
+	Name string `jsonry:"name,omitempty"`
+	// ServiceInstanceGUID is the service instance that this binding originates from
+	ServiceInstanceGUID string `jsonry:"relationships.service_instance.data.guid,omitempty"`
+	// AppGUID is the application that this binding is attached to
+	AppGUID string `jsonry:"relationships.app.data.guid,omitempty"`
+	// AppName is the application name. It is not part of the API response, and is here as pragmatic convenience.
+	AppName string `jsonry:"-"`
+	// AppSpaceGUID is the space guid of the app. It is not part of the API response, and is here as pragmatic convenience.
+	AppSpaceGUID string `jsonry:"-"`
+	// LastOperation is the last operation on the service credential binding
+	LastOperation LastOperation `jsonry:"last_operation"`
+	// Parameters can be specified when creating a binding
+	// Omit empty to fix errors with user-provided services
+	Parameters types.OptionalObject `jsonry:"parameters,omitempty"`
+}
+
+func (s ServiceCredentialBinding) MarshalJSON() ([]byte, error) {
+	return jsonry.Marshal(s)
+}
+
+func (s *ServiceCredentialBinding) UnmarshalJSON(data []byte) error {
+	return jsonry.Unmarshal(data, s)
+}

--- a/resources/service_instance_resource.go
+++ b/resources/service_instance_resource.go
@@ -1,0 +1,54 @@
+package resources
+
+import (
+	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/jsonry"
+)
+
+type ServiceInstanceType string
+
+const (
+	UserProvidedServiceInstance ServiceInstanceType = "user-provided"
+	ManagedServiceInstance      ServiceInstanceType = "managed"
+)
+
+type ServiceInstance struct {
+	// Type is either "user-provided" or "managed"
+	Type ServiceInstanceType `jsonry:"type,omitempty"`
+	// GUID is a unique service instance identifier.
+	GUID string `jsonry:"guid,omitempty"`
+	// Name is the name of the service instance.
+	Name string `jsonry:"name,omitempty"`
+	// SpaceGUID is the space that this service instance relates to
+	SpaceGUID string `jsonry:"relationships.space.data.guid,omitempty"`
+	// ServicePlanGUID is the service plan that this service instance relates to
+	ServicePlanGUID string `jsonry:"relationships.service_plan.data.guid,omitempty"`
+	// Tags are used by apps to identify service instances.
+	Tags types.OptionalStringSlice `jsonry:"tags"`
+	// SyslogDrainURL is where logs are streamed
+	SyslogDrainURL types.OptionalString `jsonry:"syslog_drain_url"`
+	// RouteServiceURL is where requests for bound routes will be forwarded
+	RouteServiceURL types.OptionalString `jsonry:"route_service_url"`
+	// DashboardURL is where the service can be monitored
+	DashboardURL types.OptionalString `jsonry:"dashboard_url"`
+	// Credentials are passed to the app
+	Credentials types.OptionalObject `jsonry:"credentials"`
+	// UpgradeAvailable says whether the plan is at a higher version
+	UpgradeAvailable types.OptionalBoolean `json:"upgrade_available"`
+	// MaintenanceInfoVersion is the version this service is at
+	MaintenanceInfoVersion string `jsonry:"maintenance_info.version,omitempty"`
+	// Parameters are passed to the service broker
+	Parameters types.OptionalObject `jsonry:"parameters"`
+	// LastOperation is the last operation on the service instance
+	LastOperation LastOperation `jsonry:"last_operation"`
+
+	Metadata *Metadata `json:"metadata,omitempty"`
+}
+
+func (s ServiceInstance) MarshalJSON() ([]byte, error) {
+	return jsonry.Marshal(s)
+}
+
+func (s *ServiceInstance) UnmarshalJSON(data []byte) error {
+	return jsonry.Unmarshal(data, s)
+}

--- a/resources/service_instance_usage_summary_resource.go
+++ b/resources/service_instance_usage_summary_resource.go
@@ -1,0 +1,22 @@
+package resources
+
+import (
+	"code.cloudfoundry.org/jsonry"
+)
+
+type ServiceInstanceUsageSummaryList struct {
+	UsageSummary []ServiceInstanceUsageSummary `jsonry:"usage_summary"`
+}
+
+func (s *ServiceInstanceUsageSummaryList) UnmarshalJSON(data []byte) error {
+	return jsonry.Unmarshal(data, s)
+}
+
+type ServiceInstanceUsageSummary struct {
+	SpaceGUID     string `jsonry:"space.guid""`
+	BoundAppCount int    `jsonry:"bound_app_count"`
+}
+
+func (s *ServiceInstanceUsageSummary) UnmarshalJSON(data []byte) error {
+	return jsonry.Unmarshal(data, s)
+}

--- a/resources/service_plan_resource.go
+++ b/resources/service_plan_resource.go
@@ -1,0 +1,36 @@
+package resources
+
+import "code.cloudfoundry.org/jsonry"
+
+type ServicePlanCost struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
+	Unit     string  `json:"unit"`
+}
+
+type ServicePlan struct {
+	// GUID is a unique service plan identifier.
+	GUID string `json:"guid"`
+	// Name is the name of the service plan.
+	Name string `json:"name"`
+	// Description of the Service Plan.
+	Description string `json:"description"`
+	// Whether the Service Plan is available
+	Available bool `json:"available"`
+	// VisibilityType can be "public", "admin", "organization" or "space"
+	VisibilityType ServicePlanVisibilityType `json:"visibility_type"`
+	// Free shows whether or not the Service Plan is free of charge.
+	Free bool `json:"free"`
+	// Cost shows the cost of a paid service plan
+	Costs []ServicePlanCost `json:"costs"`
+	// ServicePlanGUID is the GUID of the service offering
+	ServiceOfferingGUID string `jsonry:"relationships.service_offering.data.guid"`
+	// SpaceGUID is the space that a plan from a space-scoped broker relates to
+	SpaceGUID string `jsonry:"relationships.space.data.guid"`
+
+	Metadata *Metadata `json:"metadata"`
+}
+
+func (p *ServicePlan) UnmarshalJSON(data []byte) error {
+	return jsonry.Unmarshal(data, p)
+}

--- a/resources/shared_to_spaces_resource.go
+++ b/resources/shared_to_spaces_resource.go
@@ -1,0 +1,15 @@
+package resources
+
+import (
+	"code.cloudfoundry.org/jsonry"
+)
+
+type SharedToSpacesListWrapper struct {
+	SharedToSpaceGUIDs []string       `jsonry:"data[].guid"`
+	Spaces             []Space        `jsonry:"included.spaces"`
+	Organizations      []Organization `jsonry:"included.organizations"`
+}
+
+func (s *SharedToSpacesListWrapper) UnmarshalJSON(data []byte) error {
+	return jsonry.Unmarshal(data, s)
+}

--- a/resources/stack_resource.go
+++ b/resources/stack_resource.go
@@ -1,0 +1,13 @@
+package resources
+
+type Stack struct {
+	// GUID is a unique stack identifier.
+	GUID string `json:"guid"`
+	// Name is the name of the stack.
+	Name string `json:"name"`
+	// Description is the description for the stack
+	Description string `json:"description"`
+
+	// Metadata is used for custom tagging of API resources
+	Metadata *Metadata `json:"metadata,omitempty"`
+}

--- a/types/filtered_interface.go
+++ b/types/filtered_interface.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+type FilteredInterface struct {
+	IsSet bool
+	Value interface{}
+}
+
+func (n *FilteredInterface) UnmarshalJSON(rawJSON []byte) error {
+	var value interface{}
+	err := json.Unmarshal(rawJSON, &value)
+	if err != nil {
+		return err
+	}
+
+	n.Value = value
+	n.IsSet = true
+	return nil
+}
+
+func (n FilteredInterface) MarshalJSON() ([]byte, error) {
+	if n.IsSet {
+		return json.Marshal(n.Value)
+	}
+
+	return json.Marshal(new(json.RawMessage))
+}

--- a/types/json_object.go
+++ b/types/json_object.go
@@ -1,0 +1,16 @@
+package types
+
+import "encoding/json"
+
+// JSONObject represents a JSON object. When not initialized it serializes to `{}`,
+// whereas a `map[string]interface{}` serializes to `null`.
+type JSONObject map[string]interface{}
+
+func (j JSONObject) MarshalJSON() ([]byte, error) {
+	switch len(j) {
+	case 0:
+		return []byte("{}"), nil
+	default:
+		return json.Marshal(map[string]interface{}(j))
+	}
+}

--- a/types/optional_boolean.go
+++ b/types/optional_boolean.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+type OptionalBoolean struct {
+	IsSet bool
+	Value bool
+}
+
+func NewOptionalBoolean(value bool) OptionalBoolean {
+	return OptionalBoolean{
+		IsSet: true,
+		Value: value,
+	}
+}
+
+func (o *OptionalBoolean) UnmarshalJSON(rawJSON []byte) error {
+	if err := json.Unmarshal(rawJSON, &o.Value); err != nil {
+		return err
+	}
+
+	o.IsSet = true
+	return nil
+}
+
+func (o OptionalBoolean) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.Value)
+}
+
+func (o OptionalBoolean) OmitJSONry() bool {
+	return !o.IsSet
+}

--- a/types/optional_object.go
+++ b/types/optional_object.go
@@ -1,0 +1,43 @@
+package types
+
+import "encoding/json"
+
+// OptionalObject is for situations where we want to differentiate between an
+// empty object, and the object not having been set. An example would be an
+// optional command line option where we want to tell the difference between
+// it being set to an empty object, and it not being specified at all.
+type OptionalObject struct {
+	IsSet bool
+	Value map[string]interface{}
+}
+
+func NewOptionalObject(v map[string]interface{}) OptionalObject {
+	if v == nil {
+		// This ensures that when IsSet==true, we always have an empty map as the value which
+		// marshals to `{}` and not a nil map which marshals to `null`
+		v = make(map[string]interface{})
+	}
+
+	return OptionalObject{
+		IsSet: true,
+		Value: v,
+	}
+}
+
+func (o *OptionalObject) UnmarshalJSON(rawJSON []byte) error {
+	var receiver map[string]interface{}
+	if err := json.Unmarshal(rawJSON, &receiver); err != nil {
+		return err
+	}
+
+	*o = NewOptionalObject(receiver)
+	return nil
+}
+
+func (o OptionalObject) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.Value)
+}
+
+func (o OptionalObject) OmitJSONry() bool {
+	return !o.IsSet
+}

--- a/types/optional_string.go
+++ b/types/optional_string.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"encoding/json"
+)
+
+type OptionalString struct {
+	IsSet bool
+	Value string
+}
+
+func NewOptionalString(v string) OptionalString {
+	return OptionalString{
+		IsSet: true,
+		Value: v,
+	}
+}
+
+func (o *OptionalString) UnmarshalJSON(rawJSON []byte) error {
+	o.IsSet = true
+	return json.Unmarshal(rawJSON, &o.Value)
+}
+
+func (o OptionalString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.Value)
+}
+
+func (o OptionalString) OmitJSONry() bool {
+	return !o.IsSet
+}
+
+func (o OptionalString) String() string {
+	return o.Value
+}

--- a/util/lookuptable/name_from_guid.go
+++ b/util/lookuptable/name_from_guid.go
@@ -1,0 +1,20 @@
+package lookuptable
+
+import "reflect"
+
+func NameFromGUID(input interface{}) map[string]string {
+	val := reflect.ValueOf(input)
+	if val.Kind() != reflect.Slice || val.Type().Elem().Kind() != reflect.Struct {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for i := 0; i < val.Len(); i++ {
+		element := val.Index(i)
+		guid := element.FieldByName("GUID")
+		name := element.FieldByName("Name")
+		result[guid.String()] = name.String()
+	}
+
+	return result
+}

--- a/util/lookuptable/resource_from_guid.go
+++ b/util/lookuptable/resource_from_guid.go
@@ -1,0 +1,27 @@
+package lookuptable
+
+import "code.cloudfoundry.org/cli/resources"
+
+func OrgFromGUID(orgs []resources.Organization) map[string]resources.Organization {
+	result := make(map[string]resources.Organization)
+	for _, org := range orgs {
+		result[org.GUID] = org
+	}
+	return result
+}
+
+func SpaceFromGUID(spaces []resources.Space) map[string]resources.Space {
+	result := make(map[string]resources.Space)
+	for _, space := range spaces {
+		result[space.GUID] = space
+	}
+	return result
+}
+
+func AppFromGUID(apps []resources.Application) map[string]resources.Application {
+	result := make(map[string]resources.Application)
+	for _, app := range apps {
+		result[app.GUID] = app
+	}
+	return result
+}


### PR DESCRIPTION
(I made sure that this PR complies with the contributing guideline) 

# As this PR adds a lot of new code, I separate each resource implementation into a commit
! The code from this PR is mostly cherry-picked from the official repo of the cloudfoundry cli. With exceptions of **service_credential_bindings** and some updates to **service_instance** to account for user-provided service instances

## Description of the Change
1. The PR adds new v3 resources:
* [v3 service offering](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/465c91c6d56644fefa47bd2e335b9d82926c857b)
* [v3 service plan](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/9ddad49bdc760025062a8eb53e5c976bf4e2fc1c) 
* [v3 route](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/bad269571085d2413edab0d097936e23dd677de5)
* [v3 application](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/46a4c4de47f711dea26b994473c2a53cc6a109c4) 
* [v3 build](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/484eb5d0d7b8ec03eb7ae797f7121a57f4a47ab9)
* [v3 droplet](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/566ae892cd78610a7d20c7d32f2ce00fd4ac8965) 
* [v3 package](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/c72fc07dcd908fe33e7ec771989280f25816907f) 
* [v3 service credential binding](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/21852903bc70a6f5ef4419fdd99375f96fa46869) 
* [v3 service instance](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/4dc76613eedbf7e9e217e4a8e0cd0ab76c7fd4c3) 
* [v3 process and deployment](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/155ad099ad76ce3c2801613b52108ddce3016f8f) 
* [v3 application feature](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/f88f4b4326f0d16cb33cca0e6bbf0f4447629839) 
* [v3 environment variable](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/0b3d251482c22281e906225d58975242c4a46ae6)
* [v3 domain](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/f96cedfd1947377a26ca88f3d834e8f105cbfacb) 
* [v3 isolation segment](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/b7b6598eb0c9eb8e149bccb66184b70ecaf2aa4a) 
* [v3 space](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/dff565495688d9a632010a0d2805494437eb76f6)
* [v3 stack](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/a4aa2acf504c3cef5c4a4148ea6cbe4e22548740)
* [v3 relationship](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/85ecd340e302c4ae9eb2344621973beb17627a94) 
* [v3 process instance](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/e7c7e1a26bafc9a54ea96c748f076c61288eb9e4)

2. The PR adds some query parameter definitions:
[servicebroker guids filter](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/c63edc028499074cf11d14687472e3d7790e19ee)
[states filter](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/26551f9073d455f6eedea1feac0cd9507a27f3e5)

3. The PR modifies existing v3 resources:
[update v3 job and job url](https://github.com/cloudfoundry-community/cloudfoundry-cli/commit/3a8d35194d6ae77bef384081222063cd7eb7393e)

## Why Is This PR Valuable?
As mentioned in my previous PR, CF API v2 is deprecated and so bug fixes are not expected. the v3 API also offers better performance among other benefits.

## How Urgent Is The Change?
The changes are not urgent. However, we would like to get the latest commit tagged to be able to use it in the terraform provider repo

