### PR TITLE
Add missing requester initialization 

### DIFF
--- a/api/cloudcontroller/ccv3/client.go
+++ b/api/cloudcontroller/ccv3/client.go
@@ -131,6 +131,7 @@ func NewClient(config Config) *Client {
 		jobPollingInterval: config.JobPollingInterval,
 		jobPollingTimeout:  config.JobPollingTimeout,
 		wrappers:           append([]ConnectionWrapper{newErrorWrapper()}, config.Wrappers...),
+		Requester:          NewRequester(config),
 	}
 }
 

--- a/api/cloudcontroller/ccv3/connection_wrapper.go
+++ b/api/cloudcontroller/ccv3/connection_wrapper.go
@@ -15,3 +15,8 @@ type ConnectionWrapper interface {
 func (client *Client) WrapConnection(wrapper ConnectionWrapper) {
 	client.connection = wrapper.Wrap(client.connection)
 }
+
+// WrapConnection wraps the current Client connection in the wrapper.
+func (requester *RealRequester) WrapConnection(wrapper ConnectionWrapper) {
+	requester.connection = wrapper.Wrap(requester.connection)
+}


### PR DESCRIPTION
(I made sure that the PR follows the contributing guideline)

## Description of the Change
- NewRequester() needs to be called when initializing the cloudcontroller client
- Add the missing WrapConnection method of the Requester interface

Without these changes, the client will crash at initialization.