### PR TITLE
service route binding: migrate to ccv3

### DIFF
--- a/api/cloudcontroller/ccv3/internal/api_resources.go
+++ b/api/cloudcontroller/ccv3/internal/api_resources.go
@@ -23,7 +23,8 @@ const (
 
 	ServicePlansResource = "service_plans"
 
-	RoutesResource = "routes"
+	RoutesResource       = "routes"
+	RouteBindingResource = "service_route_bindings"
 
 	//v3 service credential binding
 	ServiceCredentialBindingsResource = "service_credential_bindings"

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -88,9 +88,12 @@ const (
 
 	GetServicePlansRequest = "GetServicePlans"
 
-	PostRouteRequest   = "PostRoute"
-	DeleteRouteRequest = "DeleteRouteRequest"
-	PatchRouteRequest  = "PatchRoute"
+	PostRouteRequest          = "PostRoute"
+	DeleteRouteRequest        = "DeleteRouteRequest"
+	PatchRouteRequest         = "PatchRoute"
+	PostRouteBindingRequest   = "PostRouteBinding"
+	GetRouteBindingsRequest   = "GetRouteBindings"
+	DeleteRouteBindingRequest = "DeleteRouteBinding"
 
 	DeleteOrphanedRoutesRequest = "DeleteOrphanedRoutes"
 	GetApplicationRoutesRequest = "GetApplicationRoutes"
@@ -197,6 +200,9 @@ var APIRoutes = []Route{
 	{Resource: RoutesResource, Path: "/", Method: http.MethodPost, Name: PostRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid", Method: http.MethodDelete, Name: DeleteRouteRequest},
 	{Resource: RoutesResource, Path: "/:route_guid", Method: http.MethodPatch, Name: PatchRouteRequest},
+	{Resource: RouteBindingResource, Path: "/", Method: http.MethodPost, Name: PostRouteBindingRequest},
+	{Resource: RouteBindingResource, Path: "/", Method: http.MethodGet, Name: GetRouteBindingsRequest},
+	{Resource: RouteBindingResource, Path: "/:route_binding_guid", Method: http.MethodDelete, Name: DeleteRouteBindingRequest},
 
 	// v3 application feature
 	{Resource: AppsResource, Path: "/:app_guid/ssh_enabled", Method: http.MethodGet, Name: GetSSHEnabled},

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -29,6 +29,10 @@ const (
 	ServiceBrokerGUIDsFilter QueryKey = "service_broker_guids"
 	// ServiceBrokerNamesFilter is a query parameter when getting plans or offerings according to the Service Brokers that it relates to
 	ServiceBrokerNamesFilter QueryKey = "service_broker_names"
+	// ServiceInstanceGUIDFilter is a query parameter for listing objects by service instance GUID.
+	ServiceInstanceGUIDFilter QueryKey = "service_instance_guids"
+	// RouteGUIDFilter is a query parameter for listing objects by route GUID.
+	RouteGUIDFilter QueryKey = "route_guids"
 	// StatesFilter is a query parameter when getting a package's droplets by state
 	StatesFilter QueryKey = "states"
 	// HostsFilter is a query param for listing objects by hostname

--- a/api/cloudcontroller/ccv3/route_binding.go
+++ b/api/cloudcontroller/ccv3/route_binding.go
@@ -1,0 +1,36 @@
+package ccv3
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+	"code.cloudfoundry.org/cli/resources"
+)
+
+func (client *Client) CreateRouteBinding(binding resources.RouteBinding) (JobURL, Warnings, error) {
+	return client.MakeRequest(RequestParams{
+		RequestName: internal.PostRouteBindingRequest,
+		RequestBody: binding,
+	})
+}
+
+func (client *Client) GetRouteBindings(query ...Query) ([]resources.RouteBinding, IncludedResources, Warnings, error) {
+	var result []resources.RouteBinding
+
+	included, warnings, err := client.MakeListRequest(RequestParams{
+		RequestName:  internal.GetRouteBindingsRequest,
+		Query:        query,
+		ResponseBody: resources.RouteBinding{},
+		AppendToList: func(item interface{}) error {
+			result = append(result, item.(resources.RouteBinding))
+			return nil
+		},
+	})
+
+	return result, included, warnings, err
+}
+
+func (client *Client) DeleteRouteBinding(guid string) (JobURL, Warnings, error) {
+	return client.MakeRequest(RequestParams{
+		RequestName: internal.DeleteRouteBindingRequest,
+		URIParams:   internal.Params{"route_binding_guid": guid},
+	})
+}

--- a/resources/route_binding.go
+++ b/resources/route_binding.go
@@ -1,0 +1,23 @@
+package resources
+
+import (
+	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/jsonry"
+)
+
+type RouteBinding struct {
+	GUID                string               `jsonry:"guid,omitempty"`
+	RouteServiceURL     string               `jsonry:"route_service_url,omitempty"`
+	ServiceInstanceGUID string               `jsonry:"relationships.service_instance.data.guid,omitempty"`
+	RouteGUID           string               `jsonry:"relationships.route.data.guid,omitempty"`
+	LastOperation       LastOperation        `jsonry:"last_operation"`
+	Parameters          types.OptionalObject `jsonry:"parameters"`
+}
+
+func (s RouteBinding) MarshalJSON() ([]byte, error) {
+	return jsonry.Marshal(s)
+}
+
+func (s *RouteBinding) UnmarshalJSON(data []byte) error {
+	return jsonry.Unmarshal(data, s)
+}


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

No

## Description of the Change

This PR adds the new ccv3 resource : service route binding. It is basically a copy and paste of the code of the official provider.


## Why Is This PR Valuable?

It allows migrating the service route binding resource in the Terraform provider to v3. SAP BTP does not support v2 API anymore, so for the Terraform provider to work we need to migrate its resources to v3.

PR in Terraform provider: https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/pull/572

## How urgent is the change?

Since we cannot use the v2 resources API in SAP BTP, we currently cannot manage service route bindings the Terraform provider, which makes it kind of urgent.
